### PR TITLE
[TEST-293] - Unable to run MicroProfile TCK Health on payara-micro-managed

### DIFF
--- a/MicroProfile-Health/tck-runner/pom.xml
+++ b/MicroProfile-Health/tck-runner/pom.xml
@@ -76,21 +76,19 @@
             <scope>test</scope>
         </dependency>
         
-        <!-- CAUSES ISSUES WITH MICRO MANAGED -->
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>tck-arquillian-extension</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
             <exclusions>
-                <!-- exclude dependency inheritance for server-managed from tck extention -->
+                <!-- exclude dependency inheritance for server-managed from tck extension -->
                 <exclusion>
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-server-4-managed</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- CAUSES ISSUES WITH MICRO MANAGED -->
         
     </dependencies>
 

--- a/MicroProfile-Health/tck-runner/pom.xml
+++ b/MicroProfile-Health/tck-runner/pom.xml
@@ -70,17 +70,28 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>tck-arquillian-extension</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>fish.payara.arquillian</groupId>
             <artifactId>payara-client-ee7</artifactId>
             <version>${payara.arquillian.container.version}</version>
             <scope>test</scope>
         </dependency>
+        
+        <!-- CAUSES ISSUES WITH MICRO MANAGED -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tck-arquillian-extension</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <!-- exclude dependency inheritance for server-managed from tck extention -->
+                <exclusion>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>arquillian-payara-server-4-managed</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <!-- CAUSES ISSUES WITH MICRO MANAGED -->
+        
     </dependencies>
 
     <build>


### PR DESCRIPTION
Caused by unwanted dependency inheritance in tck-arquillian-extension pom
Tested against micro-managed, server-managed and server-remote