### PR TITLE
Use REST Client TCK version 1.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .classpath
 .factorypath
 .settings/
+*.iml

--- a/MicroProfile-Rest-Client/tck-runner/pom.xml
+++ b/MicroProfile-Rest-Client/tck-runner/pom.xml
@@ -53,6 +53,11 @@
     <packaging>jar</packaging>
 
     <name>MicroProfile Rest Client TCK Runner</name>
+
+    <properties>
+        <!-- Rest Client Dependencies -->
+        <microprofile.rest.client.tck.version>1.2.1.payara-p1</microprofile.rest.client.tck.version>
+    </properties>
     
     <build>
         <plugins>
@@ -76,6 +81,7 @@
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
+                    <trimStackTrace>false</trimStackTrace>
                     <dependenciesToScan>
                         <dependency>org.eclipse.microprofile.rest.client:microprofile-rest-client-tck</dependency>
                     </dependenciesToScan>
@@ -103,7 +109,35 @@
             <artifactId>payara-client-ee8</artifactId>
             <version>${payara.arquillian.container.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.ext</groupId>
+                    <artifactId>jersey-microprofile-rest-client</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
+            <version>${microprofile.rest.client.tck.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.ext</groupId>
+            <artifactId>mp-rest-client</artifactId>
+            <version>2.29.payara-p1-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- TCK needs standalone mp config implementation. Ours works only remotely -->
+        <dependency>
+            <groupId>io.smallrye</groupId>
+            <artifactId>smallrye-config</artifactId>
+            <version>1.3.5</version>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
     <profiles>
@@ -116,8 +150,6 @@
                 </property>
             </activation>
             <properties>
-                <!-- Rest Client Dependencies -->
-                <microprofile.rest.client.tck.version>1.1.payara-p2</microprofile.rest.client.tck.version>
             </properties>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
Upgrades to service version of the TCK, which passes with our 2.29 Jersey release.

Depends on payara/Payara_PatchedProjects#242