### PR TITLE
PAYARA-3468 Added suite suitable to run MP FT 2.0 TCK

### DIFF
--- a/MicroProfile-Fault-Tolerance/tck-runner/src/test/resources/tck-suite2.0.xml
+++ b/MicroProfile-Fault-Tolerance/tck-runner/src/test/resources/tck-suite2.0.xml
@@ -1,0 +1,96 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-openapi-TCK" verbose="2" configfailurepolicy="continue" >
+
+    <test name="microprofile-openapi 2.0 TCK">
+        <packages>
+            <package name="org.eclipse.microprofile.fault.tolerance.tck.*" />
+        </packages>
+        
+        <!-- excludes -->
+        <classes>
+            <!-- exception is thrown but wrapped, added JUnit tests instead -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodWildcardNegativeTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodOutOfPackageTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSuperclassPrivateTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSubclassTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackMethodTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackMethodWithArgsTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackPolicies">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidAsynchronousClassTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidAsynchronousMethodTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidBulkheadAsynchQueueTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidBulkheadValueTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerDelayTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureRatioPosTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureRatioNegTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureReqVol0Test">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureReqVolNegTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureSuccessNegTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureSuccess0Test">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryDelayDurationTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryDelayTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryJitterTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryMaxRetriesTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidTimeoutValueTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+
+            <!-- see https://github.com/eclipse/microprofile-fault-tolerance/pull/426 -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadFutureTest">
+                <methods>
+                    <exclude name="testBulkheadClassAsynchFutureDoneAfterGet"></exclude>
+                    <exclude name="testBulkheadMethodAsynchFutureDoneAfterGet"></exclude>
+                </methods>
+            </class>
+        </classes>
+    </test>
+
+</suite>


### PR DESCRIPTION
Raw part of running MP FT 2.0 TCK. 

For now this PR just adds a suite file that has the configuration I used when testing. It includes all tests `tck.*` but then excludes those where a specific exception is expected at deployment time. These fail in the TCK since we wrap the exception in a way that will not be discovered by Arquillian. To make sure we do a similar test I added unit tests to the implementation that check the setups from the excluded TCK tests do cause a `FaultToleranceDefinitionException`. Then there are 2 excluded methods for bulkhead that are excluded since they make expectations about the implementation that aren't necessarily true. I made a PR to FT https://github.com/eclipse/microprofile-fault-tolerance/pull/426 to relax the asserts. See that PR for more details.

My plan is to make a second PR that provides the profile setup to do the "run 1.1 for older versions, run 2.0 for newer versions" once we agree over this suit addition.