### PR TITLE
TEST-198 Refactor JsonWebToken API in MP TCK Runner JWT Auth

### DIFF
--- a/MicroProfile-JWT-Auth/tck-arquillian-extension/src/main/java/fish/payara/microprofile/jwtauth/tck/TokenParser.java
+++ b/MicroProfile-JWT-Auth/tck-arquillian-extension/src/main/java/fish/payara/microprofile/jwtauth/tck/TokenParser.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) 2017 Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2017-2019] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development
@@ -60,7 +60,8 @@ public class TokenParser implements ITokenParser {
     @Override
     public JsonWebToken parse(String bearerToken, String issuer, PublicKey signedBy) throws Exception {
         try {
-            return jwtTokenParser.parse(bearerToken, issuer, signedBy);
+            jwtTokenParser.parse(bearerToken);
+            return jwtTokenParser.verify(issuer, signedBy);
         } catch (Exception e) {
             throw new IllegalStateException("", e);
         }


### PR DESCRIPTION
Reverts payara/MicroProfile-TCK-Runners#32
Requires https://github.com/payara/Payara/pull/3799

Matt's comment from the original PR: 

> I'm not able to get this compiling against the linked PR, and this will also break the TCK runner suite for all old versions of Payara. I would suggest instead making use of the new maven regex profile activator to work around this.