### PR TITLE
TEST-337: Update rest client artifact and exlude conflicting dependencies

### DIFF
--- a/MicroProfile-Rest-Client/tck-runner/pom.xml
+++ b/MicroProfile-Rest-Client/tck-runner/pom.xml
@@ -110,9 +110,28 @@
             <version>${payara.arquillian.container.version}</version>
             <scope>test</scope>
             <exclusions>
+                <!-- depending on version of ee8-client, the possibly
+                     conflicting rest client implementation is either of these -->
+                <exclusion>
+                    <groupId>org.glassfish.jersey.ext.microprofile</groupId>
+                    <artifactId>jersey-mp-rest-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.ext</groupId>
+                    <artifactId>jersey-mp-rest-client</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.glassfish.jersey.ext</groupId>
                     <artifactId>jersey-microprofile-rest-client</artifactId>
+                </exclusion>
+                <!-- Jersey internals may be incompatible to those needed by rest client -->
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.glassfish.jersey.core</groupId>
+                    <artifactId>jersey-common</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -124,9 +143,9 @@
         </dependency>
 
         <dependency>
-            <groupId>org.glassfish.jersey.ext</groupId>
-            <artifactId>mp-rest-client</artifactId>
-            <version>2.29.payara-p1-SNAPSHOT</version>
+            <groupId>org.glassfish.jersey.ext.microprofile</groupId>
+            <artifactId>jersey-mp-rest-client</artifactId>
+            <version>2.29.payara-p2</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
ee8-client still depends on Jersey 2.27, and its internals differ to those of 2.29, therefore it had to be excluded.