### PR TITLE
TEST-350 Corrected which suite micro should be using

### DIFF
--- a/MicroProfile-Fault-Tolerance/tck-runner/pom.xml
+++ b/MicroProfile-Fault-Tolerance/tck-runner/pom.xml
@@ -258,7 +258,7 @@
                                 <EXTRA_MICRO_OPTIONS>--prebootcommandfile ${basedir}/micro-pre-boot-commands.txt</EXTRA_MICRO_OPTIONS>
                             </environmentVariables>
                             <suiteXmlFiles>
-                                <suiteXmlFile>${basedir}/src/test/resources/no-ext-libs-tck-suite.xml</suiteXmlFile>
+                                <suiteXmlFile>${basedir}/src/test/resources/${microprofile.fault-tolerance.tck.suite}</suiteXmlFile>
                             </suiteXmlFiles>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
Seems micro was forgotten from a previous change relating to Microprofile 2.0 and a stability fix. This change makes use of the new property for suite file