### PR TITLE
PAYARA-4013 Upgrade MP Fault tolerance version to 2.0.1

### DIFF
--- a/MicroProfile-Fault-Tolerance/tck-runner/pom.xml
+++ b/MicroProfile-Fault-Tolerance/tck-runner/pom.xml
@@ -56,8 +56,8 @@
 
     <properties>
         <!-- Defaults for API and TCK dependencies - latest version -->
-        <microprofile.fault-tolerance.version>2.0</microprofile.fault-tolerance.version>
-        <microprofile.fault-tolerance.tck.version>2.0</microprofile.fault-tolerance.tck.version>
+        <microprofile.fault-tolerance.version>2.0.1</microprofile.fault-tolerance.version>
+        <microprofile.fault-tolerance.tck.version>2.0.1</microprofile.fault-tolerance.tck.version>
         <microprofile.fault-tolerance.tck.suite>tck-suite2.0.xml</microprofile.fault-tolerance.tck.suite>
 
         <!-- Test Dependencies -->
@@ -128,8 +128,8 @@
                 </property>
             </activation>
             <properties>
-                <microprofile.fault-tolerance.version>2.0</microprofile.fault-tolerance.version>
-                <microprofile.fault-tolerance.tck.version>2.0</microprofile.fault-tolerance.tck.version>
+                <microprofile.fault-tolerance.version>2.0.1</microprofile.fault-tolerance.version>
+                <microprofile.fault-tolerance.tck.version>2.0.1</microprofile.fault-tolerance.tck.version>
                 <microprofile.fault-tolerance.tck.suite>tck-suite2.0-stable.xml</microprofile.fault-tolerance.tck.suite>
             </properties>
         </profile>


### PR DESCRIPTION
For compatibility with MP Metrics 2.0
for https://github.com/payara/Payara/pull/4108