### PR TITLE
[TEST-361] - MP Rest-Client TCK fails on Payara 4

### DIFF
--- a/MicroProfile-Rest-Client/tck-runner/pom.xml
+++ b/MicroProfile-Rest-Client/tck-runner/pom.xml
@@ -56,7 +56,8 @@
 
     <properties>
         <!-- Rest Client Dependencies -->
-        <microprofile.rest.client.tck.version>1.2.1.payara-p1</microprofile.rest.client.tck.version>
+	<microprofile.rest.client.tck.version>1.2.1.payara-p1</microprofile.rest.client.tck.version>
+	<microprofile.rest.client.api.version>1.2.1.payara-p1</microprofile.rest.client.api.version>
     </properties>
     
     <build>
@@ -138,7 +139,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>
             <artifactId>microprofile-rest-client-api</artifactId>
-            <version>${microprofile.rest.client.tck.version}</version>
+            <version>${microprofile.rest.client.api.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Created a separate property for the MP API version so as to not pull in an old version when testing against Payara 4 - Tests now pass on 4 and 5