### PR TITLE
[TEST-369] - Resolved MP JWT-Auth failure

### DIFF
--- a/MicroProfile-JWT-Auth/tck-arquillian-extension/pom.xml
+++ b/MicroProfile-JWT-Auth/tck-arquillian-extension/pom.xml
@@ -65,7 +65,7 @@
             <activation>
                 <property>
                     <name>payara.version</name>
-                    <value>/5\.([1-9][9][3-4]|[2-9][0-9][0-9])/</value>
+                    <value>/^[5-9]\.(19[3-4]|[2-9]\d{2})(?:-SNAPSHOT|\.\d*)?/</value>
                 </property>
             </activation>
             <dependencies>
@@ -84,7 +84,7 @@
                             <version>3.8.1</version>
                             <configuration>
                                 <excludes>
-                                    <exclude>fish/payara/microprofile/jwtauth/tck/TokenParser.java</exclude>
+                                    <exclude>fish/payara/microprofile/jwtauth/tck/MockTokenParser.java</exclude>
                                 </excludes>
                             </configuration>
                         </plugin>

--- a/MicroProfile-JWT-Auth/tck-arquillian-extension/src/main/java/fish/payara/microprofile/jwtauth/tck/MockTokenParser.java
+++ b/MicroProfile-JWT-Auth/tck-arquillian-extension/src/main/java/fish/payara/microprofile/jwtauth/tck/MockTokenParser.java
@@ -58,8 +58,7 @@ public class MockTokenParser {
 
     public JsonWebToken parse(String bearerToken, String issuer, PublicKey signedBy) throws Exception {
         try {
-            jwtTokenParser.parse(bearerToken);
-            return jwtTokenParser.verify(issuer, signedBy);
+                return jwtTokenParser.parse(bearerToken, issuer, signedBy);
         } catch (Exception e) {
             throw new IllegalStateException("", e);
         }


### PR DESCRIPTION
Reverted state of MockTokenParser to match requirements of 5.192 and below and repaired regex statement in pom.xml to exclude the build in class when testing 5.193-SNAPSHOT and later - Resolves JWT-Auth TCK failure against Payara 4 versions