### PR TITLE
Fix rest client maintenance branches

### DIFF
--- a/MicroProfile-Rest-Client/tck-runner/pom.xml
+++ b/MicroProfile-Rest-Client/tck-runner/pom.xml
@@ -82,7 +82,6 @@
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <trimStackTrace>false</trimStackTrace>
                     <dependenciesToScan>
                         <dependency>org.eclipse.microprofile.rest.client:microprofile-rest-client-tck</dependency>
                     </dependenciesToScan>
@@ -110,73 +109,91 @@
             <artifactId>payara-client-ee8</artifactId>
             <version>${payara.arquillian.container.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <!-- depending on version of ee8-client, the possibly
-                     conflicting rest client implementation is either of these -->
-                <exclusion>
-                    <groupId>org.glassfish.jersey.ext.microprofile</groupId>
-                    <artifactId>jersey-mp-rest-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.ext</groupId>
-                    <artifactId>jersey-mp-rest-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.ext</groupId>
-                    <artifactId>jersey-microprofile-rest-client</artifactId>
-                </exclusion>
-                <!-- Jersey internals may be incompatible to those needed by rest client -->
-                <exclusion>
-                    <groupId>org.glassfish.jersey.core</groupId>
-                    <artifactId>jersey-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.glassfish.jersey.core</groupId>
-                    <artifactId>jersey-common</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>
-            <artifactId>microprofile-rest-client-api</artifactId>
-            <version>${microprofile.rest.client.api.version}</version>
-            <scope>test</scope>
+            <artifactId>microprofile-rest-client-tck</artifactId>
+            <version>${microprofile.rest.client.tck.version}</version>
+            <scope>runtime</scope>
         </dependency>
-
-        <dependency>
-            <groupId>org.glassfish.jersey.ext.microprofile</groupId>
-            <artifactId>jersey-mp-rest-client</artifactId>
-            <version>2.29.payara-p2</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- TCK needs standalone mp config implementation. Ours works only remotely -->
-        <dependency>
-            <groupId>io.smallrye</groupId>
-            <artifactId>smallrye-config</artifactId>
-            <version>1.3.5</version>
-            <scope>provided</scope>
-        </dependency>
-
     </dependencies>
 
     <profiles>
+        <!-- Payara 5 versions up to and including 5.192 -->
         <profile>
-            <id>payara5</id>
+            <id>payara5.192-</id>
             <activation>
                 <property>
                     <name>payara.version</name>
-                    <value>/5.+/</value>
+                    <value>/5\.1(8\d*|9[1-2])(?:-SNAPSHOT|\.\d*)?/</value>
+                </property>
+            </activation>
+            <properties>
+                <microprofile.rest.client.tck.version>1.1.payara-p2</microprofile.rest.client.tck.version>
+                <microprofile.rest.client.api.version>1.1.payara-p2</microprofile.rest.client.api.version>
+            </properties>
+        </profile>
+        <!-- Payara 5 versions from 5.193 -->
+        <profile>
+            <id>payara5.193+</id>
+            <activation>
+                <property>
+                    <name>payara.version</name>
+                    <value>/^[5-9]\.(193|[2-9]\d{2})(?:-SNAPSHOT|\.\d*)?/</value>
                 </property>
             </activation>
             <properties>
             </properties>
             <dependencies>
                 <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>payara-client-ee8</artifactId>
+                    <version>${payara.arquillian.container.version}</version>
+                    <scope>test</scope>
+                    <exclusions>
+                        <!-- depending on version of ee8-client, the possibly
+                             conflicting rest client implementation is either of these -->
+                        <exclusion>
+                            <groupId>org.glassfish.jersey.ext.microprofile</groupId>
+                            <artifactId>jersey-mp-rest-client</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.glassfish.jersey.ext</groupId>
+                            <artifactId>jersey-mp-rest-client</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.glassfish.jersey.ext</groupId>
+                            <artifactId>jersey-microprofile-rest-client</artifactId>
+                        </exclusion>
+                        <!-- Jersey internals may be incompatible to those needed by rest client -->
+                        <exclusion>
+                            <groupId>org.glassfish.jersey.core</groupId>
+                            <artifactId>jersey-client</artifactId>
+                        </exclusion>
+                        <exclusion>
+                            <groupId>org.glassfish.jersey.core</groupId>
+                            <artifactId>jersey-common</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
                     <groupId>org.eclipse.microprofile.rest.client</groupId>
-                    <artifactId>microprofile-rest-client-tck</artifactId>
-                    <version>${microprofile.rest.client.tck.version}</version>
-                    <scope>runtime</scope>
+                    <artifactId>microprofile-rest-client-api</artifactId>
+                    <version>${microprofile.rest.client.api.version}</version>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.glassfish.jersey.ext.microprofile</groupId>
+                    <artifactId>jersey-mp-rest-client</artifactId>
+                    <version>2.29.payara-p2</version>
+                    <scope>test</scope>
+                </dependency>
+                <!-- TCK needs standalone mp config implementation. Ours works only remotely -->
+                <dependency>
+                    <groupId>io.smallrye</groupId>
+                    <artifactId>smallrye-config</artifactId>
+                    <version>1.3.5</version>
+                    <scope>provided</scope>
                 </dependency>
             </dependencies>
         </profile>
@@ -192,14 +209,6 @@
                 <!-- Rest Client Dependencies -->
                 <microprofile.rest.client.tck.version>1.0.1.payara-p2</microprofile.rest.client.tck.version>
             </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>org.eclipse.microprofile.rest.client</groupId>
-                    <artifactId>microprofile-rest-client-tck</artifactId>
-                    <version>${microprofile.rest.client.tck.version}</version>
-                    <scope>runtime</scope>
-                </dependency>
-            </dependencies>
         </profile>
         <profile>
             <id>payara-server-managed</id>

--- a/MicroProfile-Rest-Client/tck-runner/pom.xml
+++ b/MicroProfile-Rest-Client/tck-runner/pom.xml
@@ -82,6 +82,7 @@
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
+                    <trimStackTrace>false</trimStackTrace>
                     <dependenciesToScan>
                         <dependency>org.eclipse.microprofile.rest.client:microprofile-rest-client-tck</dependency>
                     </dependenciesToScan>
@@ -119,13 +120,13 @@
     </dependencies>
 
     <profiles>
-        <!-- Payara 5 versions up to and including 5.192 -->
+        <!-- Payara 5 versions up to but excluding 5.192 -->
         <profile>
             <id>payara5.192-</id>
             <activation>
                 <property>
                     <name>payara.version</name>
-                    <value>/5\.1(8\d*|9[1-2])(?:-SNAPSHOT|\.\d*)?/</value>
+                    <value>/5\.1(8\d*|91)(?:-SNAPSHOT|\.\d*)?/</value>
                 </property>
             </activation>
             <properties>
@@ -133,13 +134,13 @@
                 <microprofile.rest.client.api.version>1.1.payara-p2</microprofile.rest.client.api.version>
             </properties>
         </profile>
-        <!-- Payara 5 versions from 5.193 -->
+        <!-- Payara 5 versions from 5.192 -->
         <profile>
             <id>payara5.193+</id>
             <activation>
                 <property>
                     <name>payara.version</name>
-                    <value>/^[5-9]\.(193|[2-9]\d{2})(?:-SNAPSHOT|\.\d*)?/</value>
+                    <value>/^[5-9]\.(19[2-4]|[2-9]\d{2})(?:-SNAPSHOT|\.\d*)?/</value>
                 </property>
             </activation>
             <properties>


### PR DESCRIPTION
Payara 5.192 included a Rest Client version update.
These changes should allow us to run the TCK against 5.191 and 5.192+ without constantly having to faff about with the dependencies & versions.