### PR TITLE
[PAYARA-4148] - Added missing dependency exclusion

### DIFF
--- a/MicroProfile-JWT-Auth/tck-runner/pom.xml
+++ b/MicroProfile-JWT-Auth/tck-runner/pom.xml
@@ -63,6 +63,10 @@
                     <groupId>fish.payara.microprofile.jwt-auth</groupId>
                     <artifactId>microprofile-jwt-auth</artifactId>
                 </exclusion>
+				<exclusion>
+					<groupId>fish.payara.server.internal.payara-appserver-modules</groupId>
+					<artifactId>microprofile-jwt-auth</artifactId>
+				</exclusion>
                  <!-- exclude dependency inheritance for server-managed from tck extension -->
                 <exclusion>
                     <groupId>fish.payara.arquillian</groupId>


### PR DESCRIPTION
There was a missing dependency exclusion in the tck-runner pom that is causing the test suite to error out when running against 5.194+

Tested locally without change: Fails
Tested locally with change: Passes