### PR TITLE
Fix Regex Profile Activator Extension Version

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -4,7 +4,7 @@
     <extension>
         <groupId>fish.payara.maven.extensions</groupId>
         <artifactId>regex-profile-activator</artifactId>
-        <version>0.5</version>
+        <version>0.4</version>
     </extension>
 
 </extensions>


### PR DESCRIPTION
Caused by https://github.com/payara/MicroProfile-TCK-Runners/pull/64.

Version 0.5 of the extension doesn't exist :wink:

Tut tut tut