### PR TITLE
CUSTCOM-116 Leaking Managed Connector Dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,7 @@
                     <groupId>fish.payara.arquillian</groupId>
                     <artifactId>arquillian-payara-server-managed</artifactId>
                     <version>${payara.arquillian.container.version}</version>
+                    <optional>true</optional>
                 </dependency>
             </dependencies>
             <build>
@@ -194,6 +195,7 @@
                     <artifactId>arquillian-payara-server-remote</artifactId>
                     <version>${payara.arquillian.container.version}</version>
                     <scope>test</scope>
+                    <optional>true</optional>
                 </dependency>
             </dependencies>
         </profile>
@@ -209,6 +211,7 @@
                     <artifactId>arquillian-payara-micro-managed</artifactId>
                     <version>${payara.arquillian.container.version}</version>
                     <scope>test</scope>
+                    <optional>true</optional>
                 </dependency>
             </dependencies>
             <build>
@@ -250,6 +253,7 @@
                     <artifactId>arquillian-payara-server-embedded</artifactId>
                     <version>${payara.arquillian.container.version}</version>
                     <scope>test</scope>
+                    <optional>true</optional>
                 </dependency>
                 <dependency>
                     <groupId>javax</groupId>


### PR DESCRIPTION
See commit message for details.

Ran the health TCK against 5.194.1 on remote profile (which fails otherwise).

I've added the optional flag to make none of the connectors include themselves transiently.