### PR TITLE
QACI-46 Use updated resteasy-client

### DIFF
--- a/MicroProfile-OpenTracing/tck-runner/pom.xml
+++ b/MicroProfile-OpenTracing/tck-runner/pom.xml
@@ -94,7 +94,7 @@
             <version>${payara.arquillian.container.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- Probably a "Duck tape fix":
+        <!-- Workaround:
              Use an updated version of resteasy client compared to that of the TCK.
              Using their one (3.1.4) seems to end up with a comparison failure of the HTTP status tag at
              TestSpan.equals() due to it getting transformed from an Integer to a BigDecimal between the return method

--- a/MicroProfile-OpenTracing/tck-runner/pom.xml
+++ b/MicroProfile-OpenTracing/tck-runner/pom.xml
@@ -56,17 +56,25 @@
 
     <properties>
         <!-- OpenTracing Dependencies -->
-        <microprofile.opentracing.version>1.3.1</microprofile.opentracing.version>
-        <microprofile.opentracing.tck.rest-client.version>1.3.1</microprofile.opentracing.tck.rest-client.version>
-        <microprofile.opentracing.tck.version>1.3.1.payara-p1</microprofile.opentracing.tck.version>
+        <microprofile.opentracing.version>1.3.2.payara-p1</microprofile.opentracing.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>org.eclipse.microprofile.opentracing</groupId>
             <artifactId>microprofile-opentracing-tck</artifactId>
-            <version>${microprofile.opentracing.tck.version}</version>
+            <version>${microprofile.opentracing.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.resteasy</groupId>
+                    <artifactId>resteasy-jackson-provider</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.opentracing</groupId>
@@ -77,13 +85,31 @@
         <dependency>
             <groupId>org.eclipse.microprofile.opentracing</groupId>
             <artifactId>microprofile-opentracing-tck-rest-client</artifactId>
-            <version>${microprofile.opentracing.tck.rest-client.version}</version>
+            <version>${microprofile.opentracing.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>fish.payara.arquillian</groupId>
             <artifactId>payara-client-ee7</artifactId>
             <version>${payara.arquillian.container.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Probably a "Duck tape fix":
+             Use an updated version of resteasy client compared to that of the TCK.
+             Using their one (3.1.4) seems to end up with a comparison failure of the HTTP status tag at
+             TestSpan.equals() due to it getting transformed from an Integer to a BigDecimal between the return method
+             of TracerWebService.getTracer() and OpenTracingBaseTests.executeRemoteWebServiceRaw() despite actually
+             being the same number (e.g. 200) -->
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-client</artifactId>
+            <version>3.10.0.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.resteasy</groupId>
+            <artifactId>resteasy-jackson-provider</artifactId>
+            <version>3.10.0.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/MicroProfile-OpenTracing/tck-runner/pom.xml
+++ b/MicroProfile-OpenTracing/tck-runner/pom.xml
@@ -2,7 +2,7 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   
-   Copyright (c) [2017-2018] Payara Foundation and/or its affiliates. All rights reserved.
+   Copyright (c) [2017-2020] Payara Foundation and/or its affiliates. All rights reserved.
   
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         
         <!-- Arquillian Dependencies -->
         <version.arquillian>1.1.14.Final</version.arquillian>
-        <payara.arquillian.container.version>2.0</payara.arquillian.container.version>
+        <payara.arquillian.container.version>2.1</payara.arquillian.container.version>
         
         <!-- Test Dependencies -->
         <failsafe.version>2.22.1</failsafe.version>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
   
-   Copyright (c) [2018] Payara Foundation and/or its affiliates. All rights reserved.
+   Copyright (c) [2018-2020] Payara Foundation and/or its affiliates. All rights reserved.
   
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development


### PR DESCRIPTION
Fixes OpenTracing TCK runner using updated Arquillian container.
Requires release of Arquillian Container 2.1 to apply fix for server-managed.