### PR TITLE
APPSERV-57 Adds 2.1 TCK as new default and new profile

### DIFF
--- a/MicroProfile-Fault-Tolerance/tck-runner/pom.xml
+++ b/MicroProfile-Fault-Tolerance/tck-runner/pom.xml
@@ -56,9 +56,9 @@
 
     <properties>
         <!-- Defaults for API and TCK dependencies - latest version -->
-        <microprofile.fault-tolerance.version>2.0.3</microprofile.fault-tolerance.version>
-        <microprofile.fault-tolerance.tck.version>2.0.3</microprofile.fault-tolerance.tck.version>
-        <microprofile.fault-tolerance.tck.suite>tck-suite2.0.xml</microprofile.fault-tolerance.tck.suite>
+        <microprofile.fault-tolerance.version>2.1</microprofile.fault-tolerance.version>
+        <microprofile.fault-tolerance.tck.version>2.1</microprofile.fault-tolerance.tck.version>
+        <microprofile.fault-tolerance.tck.suite>tck-suite2.1-stable.xml</microprofile.fault-tolerance.tck.suite>
 
         <!-- Test Dependencies -->
         <testng.version>6.9.9</testng.version>
@@ -101,6 +101,26 @@
                     </suiteXmlFiles>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.1</version>
+                <executions>
+                    <execution>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <echo>FT version     ${microprofile.fault-tolerance.version}</echo>
+                                <echo>FT TCK version ${microprofile.fault-tolerance.tck.version}</echo>
+                                <echo>FT suite       ${microprofile.fault-tolerance.tck.suite}</echo>
+                            </tasks>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 
@@ -124,13 +144,27 @@
             <activation>
                 <property>
                     <name>payara.version</name>
-                    <value>/5\.19[^1].*|5\.2.*/</value>
+                    <value>/5\.19[^1].*|5\.201.*/</value>
                 </property>
             </activation>
             <properties>
                 <microprofile.fault-tolerance.version>2.0.1</microprofile.fault-tolerance.version>
                 <microprofile.fault-tolerance.tck.version>2.0.1</microprofile.fault-tolerance.tck.version>
                 <microprofile.fault-tolerance.tck.suite>tck-suite2.0-stable.xml</microprofile.fault-tolerance.tck.suite>
+            </properties>
+        </profile>
+        <profile>
+            <id>mp-ft-2.1</id>
+            <activation>
+                <property>
+                    <name>payara.version</name>
+                    <value>5\.20[^1].*/</value>
+                </property>
+            </activation>
+            <properties>
+                <microprofile.fault-tolerance.version>2.1</microprofile.fault-tolerance.version>
+                <microprofile.fault-tolerance.tck.version>2.1</microprofile.fault-tolerance.tck.version>
+                <microprofile.fault-tolerance.tck.suite>tck-suite2.1-stable.xml</microprofile.fault-tolerance.tck.suite>
             </properties>
         </profile>
         <profile>

--- a/MicroProfile-Fault-Tolerance/tck-runner/src/test/resources/bulkhead-metrics.xml
+++ b/MicroProfile-Fault-Tolerance/tck-runner/src/test/resources/bulkhead-metrics.xml
@@ -1,0 +1,20 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-openapi-TCK" verbose="2" configfailurepolicy="continue" >
+    <test name="microprofile-openapi 2.0 TCK">
+        <classes>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest"></class>
+            <!-- 
+        <packages>
+            <package name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead"/>
+        </packages>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadFutureTest">
+                <methods>
+                    <exclude name="testBulkheadClassAsynchFutureDoneAfterGet"></exclude>
+                    <exclude name="testBulkheadMethodAsynchFutureDoneAfterGet"></exclude>
+                </methods>
+            </class>
+             -->
+        </classes>
+    </test>
+</suite>

--- a/MicroProfile-Fault-Tolerance/tck-runner/src/test/resources/tck-suite2.1-debug.xml
+++ b/MicroProfile-Fault-Tolerance/tck-runner/src/test/resources/tck-suite2.1-debug.xml
@@ -1,0 +1,12 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-FT-TCK" verbose="2" configfailurepolicy="continue" >
+
+    <test name="microprofile-FT 2.1 TCK">
+        <classes>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadAsynchTest">
+            </class>
+        </classes>
+    </test>
+
+</suite>

--- a/MicroProfile-Fault-Tolerance/tck-runner/src/test/resources/tck-suite2.1-stable.xml
+++ b/MicroProfile-Fault-Tolerance/tck-runner/src/test/resources/tck-suite2.1-stable.xml
@@ -1,0 +1,96 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-FT-TCK" verbose="2" configfailurepolicy="continue" >
+
+    <test name="microprofile-FT 2.1 TCK">
+        <packages>
+            <package name="org.eclipse.microprofile.fault.tolerance.tck.*" />
+        </packages>
+
+        <!-- excludes -->
+        <classes>
+            <!-- Unstable -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchConfigTest">
+                <!-- Work is not being done simultaneously enough... -->
+                <methods><exclude name="testBulkheadClassSemaphore3"></exclude></methods>
+            </class>
+            <!-- 
+             -->
+
+            <!-- exception is thrown but wrapped, added JUnit tests instead -->
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodWildcardNegativeTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodOutOfPackageTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSuperclassPrivateTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.fallbackmethod.FallbackMethodSubclassTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackMethodTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackMethodWithArgsTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackPolicies">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.illegalConfig.IncompatibleFallbackTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidAsynchronousClassTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidAsynchronousMethodTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidBulkheadAsynchQueueTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidBulkheadValueTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerDelayTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureRatioPosTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureRatioNegTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureReqVol0Test">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureReqVolNegTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureSuccessNegTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidCircuitBreakerFailureSuccess0Test">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryDelayDurationTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryDelayTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryJitterTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidRetryMaxRetriesTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+            <class name="org.eclipse.microprofile.fault.tolerance.tck.invalidParameters.InvalidTimeoutValueTest">
+                <methods><exclude name=".*"></exclude></methods>
+            </class>
+        </classes>
+    </test>
+
+</suite>


### PR DESCRIPTION
In combination with https://github.com/payara/Payara/pull/4568

FYI: TCK runner will now print info on what the 3 main properties were evaluated to:
```bash
     [echo] FT version     2.1
     [echo] FT TCK version 2.1
     [echo] FT suite       tck-suite2.1-stable.xml
```
Without it it was too unclear what version actually would run for a certain combination of arguments.

In my local testing TCK now passes stable with just a single test disabled that sometimes fails with

> Work is not being done simultaneously enough

which we cannot do something about - the test need to relax their expectations here.

The rest of the tests that are still ignored below the comment

> exception is thrown but wrapped

are those where the container wraps the expected exception so a test cannot verify it correctly - this is something we cannot change so they stay ignored.