### PR TITLE
[QACI-430] - Downgraded TCK Version

### DIFF
--- a/MicroProfile-Metrics/tck-runner/pom.xml
+++ b/MicroProfile-Metrics/tck-runner/pom.xml
@@ -56,8 +56,8 @@
 
     <properties>
         <!-- Metrics Dependencies -->
-    	<microprofile.metrics.version>2.3</microprofile.metrics.version>
-    	<microprofile.metrics.tck.version>2.3</microprofile.metrics.tck.version>
+    	<microprofile.metrics.version>1.1.payara-p1</microprofile.metrics.version>
+        <microprofile.metrics.tck.version>1.1.payara-p1</microprofile.metrics.tck.version>
 
     	<!-- Other Test Dependencies -->
     	<cdi.version>2.0</cdi.version>


### PR DESCRIPTION
We were testing against a version of metrics tck that payara4 doesn't support