### PR TITLE
FISH-662 Disable Fault Tolerance TCK

### DIFF
--- a/MicroProfile-Fault-Tolerance/tck-runner/pom.xml
+++ b/MicroProfile-Fault-Tolerance/tck-runner/pom.xml
@@ -62,6 +62,8 @@
 
         <!-- Test Dependencies -->
         <testng.version>6.9.9</testng.version>
+
+        <skipTests>true</skipTests>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
FISH-659 should revert this, but these need disabling in order for the
Metrics upgrade to proceed independent of FT.

Signed-off-by: Matthew Gill <matthew.gill@live.co.uk>