### PR TITLE
Re-integrate FISH-662 MicroProfile Metrics 3.0 (MP 4.0)

### DIFF
--- a/MicroProfile-Metrics/tck-runner/pom.xml
+++ b/MicroProfile-Metrics/tck-runner/pom.xml
@@ -56,8 +56,8 @@
 
     <properties>
         <!-- Metrics Dependencies -->
-    	<microprofile.metrics.version>2.3</microprofile.metrics.version>
-    	<microprofile.metrics.tck.version>2.3</microprofile.metrics.tck.version>
+    	<microprofile.metrics.version>3.0-RC4</microprofile.metrics.version>
+    	<microprofile.metrics.tck.version>3.0-RC4</microprofile.metrics.tck.version>
 
     	<!-- Other Test Dependencies -->
     	<cdi.version>2.0.SP1</cdi.version>


### PR DESCRIPTION
Reverts payara/MicroProfile-TCK-Runners#127

Looks good to merge Metrics again as FT has been disabled, so the TCK can be upgraded again.