### PR TITLE
FISH-659: Full FT 3.0 run

### DIFF
--- a/MicroProfile-Fault-Tolerance/tck-runner/pom.xml
+++ b/MicroProfile-Fault-Tolerance/tck-runner/pom.xml
@@ -38,7 +38,8 @@
    only if the new code is made subject to such option by the copyright
    holder.
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -106,9 +107,10 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${basedir}/src/test/resources/${microprofile.fault-tolerance.tck.suite}</suiteXmlFile>
                     </suiteXmlFiles>
-                    <systemPropertyVariables>
-                        <org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier>2.0</org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier>
-                    </systemPropertyVariables>                    
+                    <!-- In case times out are being missed, try this: -->
+<!--                    <systemPropertyVariables>-->
+<!--                        <org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier>2.0</org.eclipse.microprofile.fault.tolerance.tck.timeout.multiplier>-->
+<!--                    </systemPropertyVariables>-->
                 </configuration>
             </plugin>
             <plugin>
@@ -123,9 +125,9 @@
                         </goals>
                         <configuration>
                             <tasks>
-                                <echo>FT version     ${microprofile.fault-tolerance.version}</echo>
+                                <echo>FT version ${microprofile.fault-tolerance.version}</echo>
                                 <echo>FT TCK version ${microprofile.fault-tolerance.tck.version}</echo>
-                                <echo>FT suite       ${microprofile.fault-tolerance.tck.suite}</echo>
+                                <echo>FT suite ${microprofile.fault-tolerance.tck.suite}</echo>
                             </tasks>
                         </configuration>
                     </execution>
@@ -147,7 +149,7 @@
                 <microprofile.fault-tolerance.tck.suite>tck-suite2.0.xml</microprofile.fault-tolerance.tck.suite>
             </properties>
         </profile>
-    
+
         <profile>
             <id>payara-server-managed</id>
             <activation>
@@ -158,7 +160,7 @@
                     <!-- Copy the Payara artifact into the target directory -->
                     <plugin>
                         <artifactId>maven-dependency-plugin</artifactId>
-                    </plugin>                    
+                    </plugin>
                     <plugin>
                         <artifactId>maven-antrun-plugin</artifactId>
                         <version>1.8</version>
@@ -168,22 +170,23 @@
                                 <phase>pre-integration-test</phase>
                                 <configuration>
                                     <target>
-                                        <condition property="payara.executable" value="${payara.path}/bin/asadmin.bat" else="${payara.path}/bin/asadmin">
-                                            <os family="windows" />
+                                        <condition property="payara.executable" value="${payara.path}/bin/asadmin.bat"
+                                                   else="${payara.path}/bin/asadmin">
+                                            <os family="windows"/>
                                         </condition>
                                         <exec executable="${payara.executable}">
-                                            <arg value="start-domain" />
+                                            <arg value="start-domain"/>
                                         </exec>
                                         <exec executable="${payara.executable}">
-                                            <arg value="delete-jvm-options" />
-                                            <arg value="-Xmx512m" />
+                                            <arg value="delete-jvm-options"/>
+                                            <arg value="-Xmx512m"/>
                                         </exec>
                                         <exec executable="${payara.executable}">
-                                            <arg value="create-jvm-options" />
-                                            <arg value="-Xmx2g" />
+                                            <arg value="create-jvm-options"/>
+                                            <arg value="-Xmx2g"/>
                                         </exec>
                                         <exec executable="${payara.executable}">
-                                            <arg value="stop-domain" />
+                                            <arg value="stop-domain"/>
                                         </exec>
                                     </target>
                                 </configuration>
@@ -312,6 +315,32 @@
                         <filtering>true</filtering>
                     </testResource>
                 </testResources>
+            </build>
+        </profile>
+
+        <profile>
+            <id>single-test</id>
+            <activation>
+                <property>
+                    <name>it.test</name>
+                </property>
+
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <suiteXmlFiles/>
+                            <dependenciesToScan>
+                                <dependencyToScan>
+                                    org.eclipse.microprofile.fault-tolerance:microprofile-fault-tolerance-tck
+                                </dependencyToScan>
+                            </dependenciesToScan>
+                        </configuration>
+                    </plugin>
+                </plugins>
             </build>
         </profile>
     </profiles>

--- a/MicroProfile-Fault-Tolerance/tck-runner/src/test/resources/tck-suite3.0-stable.xml
+++ b/MicroProfile-Fault-Tolerance/tck-runner/src/test/resources/tck-suite3.0-stable.xml
@@ -9,29 +9,7 @@
 
         <!-- excludes -->
         <classes>
-            <!-- Unstable: Fail in fully TCK run but pass when run individually -->
-            <class name="org.eclipse.microprofile.fault.tolerance.tck.CircuitBreakerBulkheadTest">
-                <methods><exclude name="testCircuitBreakerAroundBulkheadSync"></exclude></methods>
-            </class>
-            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchRetryTest">
-                <methods><exclude name="testRetryTestExceptionMethod"></exclude></methods>
-            </class>
-            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchTest">
-                <methods><exclude name=".*"></exclude></methods>
-            </class>
-            <class name="org.eclipse.microprofile.fault.tolerance.tck.metrics.BulkheadMetricTest">
-                <methods>
-                    <exclude name="bulkheadMetricHistogramTest"></exclude>
-                    <exclude name="bulkheadMetricRejectionTest"></exclude>
-                    <exclude name="bulkheadMetricTest"></exclude>
-                </methods>
-            </class>
-            <class name="org.eclipse.microprofile.fault.tolerance.tck.bulkhead.BulkheadSynchConfigTest">
-                <methods><exclude name="testBulkheadClassSemaphore3"></exclude></methods>
-            </class>
-            <class name="org.eclipse.microprofile.fault.tolerance.tck.config.BulkheadConfigTest">
-                <methods><exclude name="testConfigValue"></exclude></methods>
-            </class>
+            <!-- Unstable -->
             <!-- 
              -->
 


### PR DESCRIPTION
Removes all excluded classes and timeout multiplier, as new version (to be posted) passes all of them