### PR TITLE
FISH-658 Enable @ConfigProperties tests

### DIFF
--- a/MicroProfile-Config/tck-runner/src/test/resources/tck-suite.xml
+++ b/MicroProfile-Config/tck-runner/src/test/resources/tck-suite.xml
@@ -10,9 +10,6 @@
         </packages>
         <!-- Exclude tests which return correct exceptions in @Before, but Arquillian wraps them which makes the tests fail -->
         <classes>
-            <class name="org.eclipse.microprofile.config.tck.ConfigPropertiesTest">
-                <methods><exclude name=".*"></exclude></methods>
-            </class>
             <class name="org.eclipse.microprofile.config.tck.converters.convertToNull.ConvertedNullValueBrokenInjectionTest">
                 <methods><exclude name=".*"></exclude></methods>
             </class>


### PR DESCRIPTION
This class was disabled in error, and revealed a hole in functionality