### PR TITLE
QACI-625 MP Config Micro System Properties Fix

### DIFF
--- a/MicroProfile-Config/tck-runner/pom.xml
+++ b/MicroProfile-Config/tck-runner/pom.xml
@@ -255,12 +255,14 @@
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
-                            <systemProperties>
+                            <systemPropertyVariables>
+                                <!-- Configure system properties for the server process in the arquillian.xml -->
+                                <arquillian.launch>payara-micro-managed</arquillian.launch>
                                 <!-- Required for DefaultConfigSourceOrdinalTest -->
                                 <config_ordinal>120</config_ordinal>
                                 <customer.hobby>Tennis</customer.hobby>
                                 <mp.tck.prop.dummy>dummy</mp.tck.prop.dummy>
-                            </systemProperties>
+                            </systemPropertyVariables>
                             <environmentVariables>
                                 <MICRO_JAR>${payara.micro.path}</MICRO_JAR>
                                 <!-- Required for DefaultConfigSourceOrdinalTest -->

--- a/MicroProfile-Config/tck-runner/src/test/resources/arquillian.xml
+++ b/MicroProfile-Config/tck-runner/src/test/resources/arquillian.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian
+    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+  
+    <container qualifier="payara-micro-managed">
+        <configuration>
+            <!-- Required for DefaultConfigSourceOrdinalTest -->
+            <property name="cmdOptions">
+                -Dconfig_ordinal=120
+                -Dcustomer.hobby=Tennis
+                -Dmp.tck.prop.dummy=dummy
+            </property>
+        </configuration>
+    </container>
+
+</arquillian> 


### PR DESCRIPTION
The systemPropertyVariables block in the payara-micro config doesn't pass properties to the micro instance as expected. I've changed the configuration to utilise the cmdOptions arquillian config to pass it to the micro instance on the command line.

Should resolve issue seen at http://192.168.1.120:8080/job/TestMPTCKs/2589/testReport/junit/org.eclipse.microprofile.config.tck.configsources/DefaultConfigSourceOrdinalTest/Test_MP_Config_TCK___testOrdinalForEnv/