### PR TITLE
FISH-5683 Use BigDecimal inline with the TCK

### DIFF
--- a/MicroProfile-OpenTracing/pom.xml
+++ b/MicroProfile-OpenTracing/pom.xml
@@ -65,16 +65,6 @@
             <artifactId>microprofile-opentracing-tck</artifactId>
             <version>${microprofile.opentracing.version}</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.resteasy</groupId>
-                    <artifactId>resteasy-client</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jboss.resteasy</groupId>
-                    <artifactId>resteasy-jackson-provider</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.opentracing</groupId>
@@ -93,23 +83,10 @@
             <artifactId>payara-client-ee8</artifactId>
             <scope>test</scope>
         </dependency>
-        <!-- Workaround:
-             Use an updated version of resteasy client compared to that of the TCK.
-             Using their one (3.1.4) seems to end up with a comparison failure of the HTTP status tag at
-             TestSpan.equals() due to it getting transformed from an Integer to a BigDecimal between the return method
-             of TracerWebService.getTracer() and OpenTracingBaseTests.executeRemoteWebServiceRaw() despite actually
-             being the same number (e.g. 200) -->
         <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
-            <version>3.15.1.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson-provider</artifactId>
-            <version>3.15.1.Final</version>
-            <scope>test</scope>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-binding</artifactId>
+            <version>${jersey.version}</version>
         </dependency>
     </dependencies>
 

--- a/MicroProfile-OpenTracing/pom.xml
+++ b/MicroProfile-OpenTracing/pom.xml
@@ -54,7 +54,7 @@
 
     <properties>
         <!-- OpenTracing Dependencies -->
-        <microprofile.opentracing.version>2.0.payara-p1</microprofile.opentracing.version>
+        <microprofile.opentracing.version>2.0.payara-p2</microprofile.opentracing.version>
         <mptck.suite>${basedir}/src/test/resources/tck-suite.xml</mptck.suite>
         <payara.executable>${payara.home}/bin/asadmin</payara.executable>
     </properties>

--- a/MicroProfile-OpenTracing/src/test/resources/tck-suite.xml
+++ b/MicroProfile-OpenTracing/src/test/resources/tck-suite.xml
@@ -1,7 +1,7 @@
 <!DOCTYPE suite SYSTEM "https://testng.org/testng-1.0.dtd" >
 
 <suite name="microprofile-opentracing-TCK" verbose="2" configfailurepolicy="continue" >
-    <test name="microprofile-opentracing 1.3 TCK">
+    <test name="microprofile-opentracing 2.0 TCK">
         <packages>
             <package name="org.eclipse.microprofile.opentracing.tck.*"/>
         </packages>

--- a/pom.xml
+++ b/pom.xml
@@ -58,11 +58,11 @@
         <maven.compiler.target>1.8</maven.compiler.target>
 
         <!-- Arquillian Dependencies -->
-        <payara.arquillian.container.version>2.4.4</payara.arquillian.container.version>
+        <payara.arquillian.container.version>2.4.5</payara.arquillian.container.version>
 
         <!-- Embedded Dependencies -->
         <tyrus.version>1.17.payara-p1</tyrus.version>
-        <jersey.version>2.30.payara-p4</jersey.version>
+        <jersey.version>2.34.payara-p1</jersey.version>
 
         <!-- Payara Dependencies -->
         <payara.version>5.2021.5-SNAPSHOT</payara.version>
@@ -357,7 +357,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.7.0.Alpha9</version>
+                <version>1.7.0.Alpha10</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Title.
The TCK expects BigDecimal as that's what JSON-B expects.
Jackson returns Integers and is therefore incorrect.

Linked PRs:
* https://github.com/payara/patched-src-microprofile-opentracing/pull/2
* https://github.com/payara/ecosystem-arquillian-connectors/pull/145
* https://github.com/payara/ecosystem-arquillian-connectors/pull/146
