### PR TITLE
FISH-5871 InvalidAlgorithmException in MicroProfile JWT on JDK 17

### DIFF
--- a/MicroProfile-JWT-Auth/pom.xml
+++ b/MicroProfile-JWT-Auth/pom.xml
@@ -55,8 +55,8 @@
 
     <properties>
         <!-- JWT Auth Dependencies -->
-        <microprofile.jwt-auth.version>1.2.1</microprofile.jwt-auth.version>
-        <microprofile.jwt-auth.tck.version>1.2.1</microprofile.jwt-auth.tck.version>
+        <microprofile.jwt-auth.version>1.2.2</microprofile.jwt-auth.version>
+        <microprofile.jwt-auth.tck.version>1.2.2</microprofile.jwt-auth.tck.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
They bumped the Jose version to fix the issue.

Tested against JDK 8, 11, and 17.