### PR TITLE
FISH-5872 Fix Health TCK for JDK 17

### DIFF
--- a/MicroProfile-Health/pom.xml
+++ b/MicroProfile-Health/pom.xml
@@ -54,7 +54,7 @@
     <name>MicroProfile Health TCK Runner Parent</name>
 
     <properties>
-        <microprofile.health.version>3.0</microprofile.health.version>
+        <microprofile.health.version>3.1</microprofile.health.version>
     </properties>
 
     <modules>

--- a/MicroProfile-Health/tck-runner/pom.xml
+++ b/MicroProfile-Health/tck-runner/pom.xml
@@ -54,6 +54,7 @@
     <properties>
         <microprofile.health.tck.version>3.1</microprofile.health.tck.version>
         <mptck.suite>${basedir}/src/test/resources/tck-suite.xml</mptck.suite>
+        <jackson.version>2.12.4</jackson.version>
     </properties>
 
     <dependencies>
@@ -87,6 +88,13 @@
                     <artifactId>arquillian-payara-server-4-managed</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <!-- Required for JDK 17, but should probably have been present anyway -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <version>${jackson.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/MicroProfile-Health/tck-runner/src/test/resources/tck-suite.xml
+++ b/MicroProfile-Health/tck-runner/src/test/resources/tck-suite.xml
@@ -2,7 +2,7 @@
 
 <suite name="microprofile-fault-tolerance-TCK" verbose="2" configfailurepolicy="continue" >
 
-    <test name="microprofile-fault-tolerance 1.0 TCK">
+    <test name="MicroProfile Health 3.1 TCK">
         <packages>
             <package name="org.eclipse.microprofile.health.tck.*"/>
         </packages>


### PR DESCRIPTION
Brings down a required dependency for JDK 17.
This dependency should probably have been present for all versions, but Jackson managed to squeeze by.

Also updates some associated text and dependencies to align with the version of MP Health we actually use.