### PR TITLE
FISH-5870 InaccessibleObjectException in MicroProfile Config & Rest Client on JDK 17

### DIFF
--- a/MicroProfile-Config/pom.xml
+++ b/MicroProfile-Config/pom.xml
@@ -83,4 +83,24 @@
             <artifactId>environment-setup</artifactId>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>jdk17</id>
+            <activation>
+                <jdk>17</jdk>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <argLine>--add-opens=java.base/java.util=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/MicroProfile-Metrics/pom.xml
+++ b/MicroProfile-Metrics/pom.xml
@@ -138,4 +138,24 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jdk17</id>
+            <activation>
+                <jdk>17</jdk>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <argLine>--add-opens=java.base/java.util=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/MicroProfile-Rest-Client/apache-httpclient-connector/pom.xml
+++ b/MicroProfile-Rest-Client/apache-httpclient-connector/pom.xml
@@ -207,7 +207,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.1.0</version>
+                <version>5.1.1</version>
                 <executions>
                     <execution>
                         <id>default-manifest</id>

--- a/MicroProfile-Rest-Client/tck-runners/pom.xml
+++ b/MicroProfile-Rest-Client/tck-runners/pom.xml
@@ -168,4 +168,23 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>jdk17</id>
+            <activation>
+                <jdk>17</jdk>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <argLine>--add-opens=java.base/java.util=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
This appears to be something within Arquillian or the TCK itself, so just adding --opens for now.

Also updates the bundle plugin to a version which likes JDK 17.