### PR TITLE
FISH-6409 Fix MP TCK issues on Payara6-tck

### DIFF
--- a/MicroProfile-Config/pom.xml
+++ b/MicroProfile-Config/pom.xml
@@ -55,8 +55,8 @@
 
     <properties>
         <!-- Config Dependencies -->
-        <microprofile.config.version>3.0.1.payara-p2</microprofile.config.version>
-        <microprofile.config.tck.version>3.0.1.payara-p2</microprofile.config.tck.version>
+        <microprofile.config.version>3.0.1</microprofile.config.version>
+        <microprofile.config.tck.version>3.0.1</microprofile.config.tck.version>
         <mptck.suite>${basedir}/src/test/resources/tck-suite.xml</mptck.suite>
         <micro.randomPort>false</micro.randomPort>
         

--- a/MicroProfile-Config/src/main/java/fish/payara/microprofile/config/tck/ArquillianArchiveProcessor.java
+++ b/MicroProfile-Config/src/main/java/fish/payara/microprofile/config/tck/ArquillianArchiveProcessor.java
@@ -70,6 +70,7 @@ public class ArquillianArchiveProcessor implements ApplicationArchiveProcessor {
         try {
             webArchive.addAsLibraries(lib(HAMCREST_ALL));
             webArchive.addAsLibraries(lib(JUNIT_DEP));
+            webArchive.addAsWebInfResource("beans.xml", "beans.xml");
         } catch (Exception e) {
             LOG.log(Level.SEVERE, "addLibraries exception", e);
         }

--- a/MicroProfile-Config/src/main/java/fish/payara/microprofile/config/tck/ArquillianArchiveProcessor.java
+++ b/MicroProfile-Config/src/main/java/fish/payara/microprofile/config/tck/ArquillianArchiveProcessor.java
@@ -1,7 +1,7 @@
 /*
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
  *
- * Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
+ * Copyright (c) [2020-2022] Payara Foundation and/or its affiliates. All rights reserved.
  *
  * The contents of this file are subject to the terms of either the GNU
  * General Public License Version 2 only ("GPL") or the Common Development

--- a/MicroProfile-Config/src/main/resources/beans.xml
+++ b/MicroProfile-Config/src/main/resources/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+         https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0" bean-discovery-mode="all">
+</beans>

--- a/MicroProfile-Fault-Tolerance/pom.xml
+++ b/MicroProfile-Fault-Tolerance/pom.xml
@@ -55,8 +55,8 @@
 
     <properties>
         <!-- Defaults for API and TCK dependencies - latest version -->
-        <microprofile.fault-tolerance.version>4.0.payara-p2</microprofile.fault-tolerance.version>
-        <microprofile.fault-tolerance.tck.version>4.0.payara-p2</microprofile.fault-tolerance.tck.version>
+        <microprofile.fault-tolerance.version>4.0</microprofile.fault-tolerance.version>
+        <microprofile.fault-tolerance.tck.version>4.0</microprofile.fault-tolerance.tck.version>
         <microprofile.metrics.version>3.0</microprofile.metrics.version>
         <mptck.suite>${basedir}/src/test/resources/tck-suite3.0-all.xml</mptck.suite>
     </properties>

--- a/MicroProfile-Fault-Tolerance/src/main/java/fish/payara/microprofile/ft/tck/ApplicationArchiveProcessorImpl.java
+++ b/MicroProfile-Fault-Tolerance/src/main/java/fish/payara/microprofile/ft/tck/ApplicationArchiveProcessorImpl.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.microprofile.ft.tck;
 
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
@@ -15,6 +54,9 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * @author ariekiswanto
+ */
 public class ApplicationArchiveProcessorImpl implements ApplicationArchiveProcessor {
 
     private static final Logger LOG = Logger.getLogger(ApplicationArchiveProcessorImpl.class.getName());

--- a/MicroProfile-Fault-Tolerance/src/main/java/fish/payara/microprofile/ft/tck/ApplicationArchiveProcessorImpl.java
+++ b/MicroProfile-Fault-Tolerance/src/main/java/fish/payara/microprofile/ft/tck/ApplicationArchiveProcessorImpl.java
@@ -1,0 +1,38 @@
+package fish.payara.microprofile.ft.tck;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.*;
+import org.jboss.shrinkwrap.api.asset.ArchiveAsset;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class ApplicationArchiveProcessorImpl implements ApplicationArchiveProcessor {
+
+    private static final Logger LOG = Logger.getLogger(ApplicationArchiveProcessorImpl.class.getName());
+
+    @Override
+    public void process(Archive<?> applicationArchive, TestClass testClass) {
+        for(Map.Entry<ArchivePath, Node> content : applicationArchive.getContent().entrySet()) {
+            if (content.getValue().getAsset() instanceof ArchiveAsset) {
+                ArchiveAsset asset = (ArchiveAsset) content.getValue().getAsset();
+                for(Map.Entry<ArchivePath, Node> contentArchive : asset.getArchive().getContent().entrySet()) {
+                    if(contentArchive.getKey().get().contains("META-INF/beans.xml")) {
+                        LOG.log(Level.INFO, "Virtually augmented content archive: \n {0}");
+                        JavaArchive javaArchive = JavaArchive.class.cast(asset.getArchive());
+                        javaArchive.delete(contentArchive.getKey());
+                        javaArchive.addAsManifestResource("beans.xml", "beans.xml");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/MicroProfile-Fault-Tolerance/src/main/java/fish/payara/microprofile/ft/tck/ApplicationArchiveProcessorImpl.java
+++ b/MicroProfile-Fault-Tolerance/src/main/java/fish/payara/microprofile/ft/tck/ApplicationArchiveProcessorImpl.java
@@ -26,7 +26,7 @@ public class ApplicationArchiveProcessorImpl implements ApplicationArchiveProces
                 ArchiveAsset asset = (ArchiveAsset) content.getValue().getAsset();
                 for(Map.Entry<ArchivePath, Node> contentArchive : asset.getArchive().getContent().entrySet()) {
                     if(contentArchive.getKey().get().contains("META-INF/beans.xml")) {
-                        LOG.log(Level.INFO, "Virtually augmented content archive: \n {0}");
+                        LOG.log(Level.INFO, "Virtually augmented content archive \n");
                         JavaArchive javaArchive = JavaArchive.class.cast(asset.getArchive());
                         javaArchive.delete(contentArchive.getKey());
                         javaArchive.addAsManifestResource("beans.xml", "beans.xml");

--- a/MicroProfile-Fault-Tolerance/src/main/java/fish/payara/microprofile/ft/tck/ArquillianExtension.java
+++ b/MicroProfile-Fault-Tolerance/src/main/java/fish/payara/microprofile/ft/tck/ArquillianExtension.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.microprofile.ft.tck;
 
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
@@ -7,6 +46,9 @@ import org.jboss.arquillian.core.spi.LoadableExtension;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * @author ariekiswanto
+ */
 public class ArquillianExtension implements LoadableExtension {
 
     private static final Logger LOG = Logger.getLogger(ArquillianExtension.class.getName());

--- a/MicroProfile-Fault-Tolerance/src/main/java/fish/payara/microprofile/ft/tck/ArquillianExtension.java
+++ b/MicroProfile-Fault-Tolerance/src/main/java/fish/payara/microprofile/ft/tck/ArquillianExtension.java
@@ -1,0 +1,19 @@
+package fish.payara.microprofile.ft.tck;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class ArquillianExtension implements LoadableExtension {
+
+    private static final Logger LOG = Logger.getLogger(ArquillianExtension.class.getName());
+
+    @Override
+    public void register(ExtensionBuilder extensionBuilder) {
+        LOG.log(Level.INFO, "\n Registered Payara TCK ArquillianExtension \n");
+        extensionBuilder.service(ApplicationArchiveProcessor.class, ApplicationArchiveProcessorImpl.class);
+    }
+}

--- a/MicroProfile-Fault-Tolerance/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/MicroProfile-Fault-Tolerance/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+fish.payara.microprofile.ft.tck.ArquillianExtension

--- a/MicroProfile-Fault-Tolerance/src/main/resources/beans.xml
+++ b/MicroProfile-Fault-Tolerance/src/main/resources/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+         https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0" bean-discovery-mode="all">
+</beans>

--- a/MicroProfile-Metrics/pom.xml
+++ b/MicroProfile-Metrics/pom.xml
@@ -55,8 +55,8 @@
 
     <properties>
         <!-- Metrics Dependencies -->
-        <microprofile.metrics.version>4.0</microprofile.metrics.version>
-        <microprofile.metrics.tck.version>4.0</microprofile.metrics.tck.version>
+        <microprofile.metrics.version>4.0.1</microprofile.metrics.version>
+        <microprofile.metrics.tck.version>4.0.1</microprofile.metrics.tck.version>
         <micro.randomPort>false</micro.randomPort>
 
         <!-- Other Test Dependencies -->

--- a/MicroProfile-Metrics/pom.xml
+++ b/MicroProfile-Metrics/pom.xml
@@ -2,7 +2,7 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-   Copyright (c) [2017-2021] Payara Foundation and/or its affiliates. All rights reserved.
+   Copyright (c) [2017-2022] Payara Foundation and/or its affiliates. All rights reserved.
 
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development

--- a/MicroProfile-Metrics/pom.xml
+++ b/MicroProfile-Metrics/pom.xml
@@ -2,7 +2,7 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-   Copyright (c) [2017-2022] Payara Foundation and/or its affiliates. All rights reserved.
+   Copyright (c) [2017-2021] Payara Foundation and/or its affiliates. All rights reserved.
 
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development
@@ -55,8 +55,8 @@
 
     <properties>
         <!-- Metrics Dependencies -->
-        <microprofile.metrics.version>4.0.1.payara-p2</microprofile.metrics.version>
-        <microprofile.metrics.tck.version>4.0.1.payara-p2</microprofile.metrics.tck.version>
+        <microprofile.metrics.version>4.0</microprofile.metrics.version>
+        <microprofile.metrics.tck.version>4.0</microprofile.metrics.tck.version>
         <micro.randomPort>false</micro.randomPort>
 
         <!-- Other Test Dependencies -->

--- a/MicroProfile-Metrics/src/main/java/fish/payara/microprofile/metrics/tck/ApplicationArchiveProcessorImpl.java
+++ b/MicroProfile-Metrics/src/main/java/fish/payara/microprofile/metrics/tck/ApplicationArchiveProcessorImpl.java
@@ -1,0 +1,17 @@
+package fish.payara.microprofile.metrics.tck;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+public class ApplicationArchiveProcessorImpl implements ApplicationArchiveProcessor {
+    @Override
+    public void process(Archive<?> archive, TestClass testClass) {
+        if (!(archive instanceof WebArchive)) {
+            return;
+        }
+        WebArchive webArchive = WebArchive.class.cast(archive);
+        webArchive.addAsWebInfResource("beans.xml", "beans.xml");
+    }
+}

--- a/MicroProfile-Metrics/src/main/java/fish/payara/microprofile/metrics/tck/ApplicationArchiveProcessorImpl.java
+++ b/MicroProfile-Metrics/src/main/java/fish/payara/microprofile/metrics/tck/ApplicationArchiveProcessorImpl.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.microprofile.metrics.tck;
 
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
@@ -5,6 +44,9 @@ import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+/**
+ * @author ariekiswanto
+ */
 public class ApplicationArchiveProcessorImpl implements ApplicationArchiveProcessor {
     @Override
     public void process(Archive<?> archive, TestClass testClass) {

--- a/MicroProfile-Metrics/src/main/java/fish/payara/microprofile/metrics/tck/ArquillianExtension.java
+++ b/MicroProfile-Metrics/src/main/java/fish/payara/microprofile/metrics/tck/ArquillianExtension.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.microprofile.metrics.tck;
 
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
@@ -6,6 +45,9 @@ import org.jboss.arquillian.core.spi.LoadableExtension;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+/**
+ * @author ariekiswanto
+ */
 public class ArquillianExtension implements LoadableExtension {
 
     private static final Logger LOG = Logger.getLogger(ArquillianExtension.class.getName());

--- a/MicroProfile-Metrics/src/main/java/fish/payara/microprofile/metrics/tck/ArquillianExtension.java
+++ b/MicroProfile-Metrics/src/main/java/fish/payara/microprofile/metrics/tck/ArquillianExtension.java
@@ -1,0 +1,18 @@
+package fish.payara.microprofile.metrics.tck;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class ArquillianExtension implements LoadableExtension {
+
+    private static final Logger LOG = Logger.getLogger(ArquillianExtension.class.getName());
+
+    @Override
+    public void register(ExtensionBuilder extensionBuilder) {
+        LOG.log(Level.INFO, "\n Registered Payara TCK ArquillianExtension \n");
+        extensionBuilder.service(ApplicationArchiveProcessor.class, ApplicationArchiveProcessorImpl.class);
+    }
+}

--- a/MicroProfile-Metrics/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/MicroProfile-Metrics/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+fish.payara.microprofile.metrics.tck.ArquillianExtension

--- a/MicroProfile-Metrics/src/main/resources/beans.xml
+++ b/MicroProfile-Metrics/src/main/resources/beans.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+         https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0" bean-discovery-mode="all">
+</beans>

--- a/MicroProfile-OpenTracing/pom.xml
+++ b/MicroProfile-OpenTracing/pom.xml
@@ -55,7 +55,7 @@
     <properties>
         <!-- OpenTracing Dependencies -->
         <microprofile.opentracing.version>3.0</microprofile.opentracing.version>
-        <microprofile.config.version>3.0.1.payara-p2</microprofile.config.version>
+        <microprofile.config.version>3.0.1</microprofile.config.version>
         <mptck.suite>${basedir}/src/test/resources/tck-suite.xml</mptck.suite>
         <payara.executable>${payara.home}/bin/asadmin</payara.executable>
     </properties>

--- a/MicroProfile-OpenTracing/src/test/java/fish/payara/arquillian/extension/ArquillianExtension.java
+++ b/MicroProfile-OpenTracing/src/test/java/fish/payara/arquillian/extension/ArquillianExtension.java
@@ -1,9 +1,51 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.arquillian.extension;
 
 import fish.payara.writer.ApplicationArchiveProcessorImpl;
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.core.spi.LoadableExtension;
 
+/**
+ * @author ariekiswanto
+ */
 public class ArquillianExtension implements LoadableExtension {
     @Override
     public void register(ExtensionBuilder extensionBuilder) {

--- a/MicroProfile-OpenTracing/src/test/java/fish/payara/writer/ApplicationArchiveProcessorImpl.java
+++ b/MicroProfile-OpenTracing/src/test/java/fish/payara/writer/ApplicationArchiveProcessorImpl.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.writer;
 
 import org.glassfish.jersey.internal.spi.AutoDiscoverable;
@@ -6,6 +45,9 @@ import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
+/**
+ * @author ariekiswanto
+ */
 public class ApplicationArchiveProcessorImpl implements ApplicationArchiveProcessor {
     @Override
     public void process(Archive<?> archive, TestClass testClass) {

--- a/MicroProfile-OpenTracing/src/test/java/fish/payara/writer/AutoDiscoverableImpl.java
+++ b/MicroProfile-OpenTracing/src/test/java/fish/payara/writer/AutoDiscoverableImpl.java
@@ -1,9 +1,51 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.writer;
 
 import jakarta.ws.rs.core.Feature;
 import jakarta.ws.rs.core.FeatureContext;
 import org.glassfish.jersey.internal.spi.AutoDiscoverable;
 
+/**
+ * @author ariekiswanto
+ */
 public class AutoDiscoverableImpl implements AutoDiscoverable {
 
     @Override

--- a/MicroProfile-OpenTracing/src/test/java/fish/payara/writer/MessageBodyWriterProvider.java
+++ b/MicroProfile-OpenTracing/src/test/java/fish/payara/writer/MessageBodyWriterProvider.java
@@ -1,3 +1,42 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) [2022] Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://github.com/payara/Payara/blob/master/LICENSE.txt
+ * See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * The Payara Foundation designates this particular file as subject to the "Classpath"
+ * exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
 package fish.payara.writer;
 
 import io.opentracing.Tracer;
@@ -15,6 +54,9 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+/**
+ * @author ariekiswanto
+ */
 @Provider
 @Produces(MediaType.APPLICATION_JSON)
 public class MessageBodyWriterProvider implements MessageBodyWriter<Tracer> {


### PR DESCRIPTION
## Description

This PR is a rework of the previous PR https://github.com/payara/MicroProfile-TCK-Runners/pull/186 since it is using patched version of TCKs that cannot be certified.
Removed patched version of TCKs, redefine beans definition by reprocessing it with beans mode `all`
