### PR TITLE
FISH 6615 fix payaramicro tck for payara micro

### DIFF
--- a/MicroProfile-Config/pom.xml
+++ b/MicroProfile-Config/pom.xml
@@ -204,7 +204,7 @@
                     <plugin>
                         <groupId>fish.payara.maven.plugins</groupId>
                         <artifactId>payara-micro-maven-plugin</artifactId>
-                        <version>1.0.6</version>
+                        <version>${payara.micro.maven.plugin.version}</version>
                         <executions>
                             <!-- Restart Payara micro with additional property -->
                             <execution>
@@ -241,6 +241,13 @@
                                         </option>
                                     </commandLineOptions>
                                 </configuration>
+                            </execution>
+                            <execution>
+                                <id>stop-test-instance-properties</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>

--- a/MicroProfile-Config/pom.xml
+++ b/MicroProfile-Config/pom.xml
@@ -117,7 +117,7 @@
                         <id>prepare-payara-server</id>
                         <phase>pre-integration-test</phase>
                         <configuration>
-                            <target unless="payara.micro.managed">
+                            <target unless="payara.micro">
                                 <exec executable="${payara.executable}">
                                     <arg value="create-system-properties" />
                                     <arg value="config_ordinal=120:customer.hobby=Tennis:mp.tck.prop.dummy=dummy" />
@@ -177,7 +177,7 @@
         <profile>
             <id>payara-micro-managed</id>
             <properties>
-                <payara.micro.managed/>
+                <payara.micro/>
             </properties>
             <build>
                 <plugins>
@@ -189,6 +189,60 @@
                                 <EXTRA_MICRO_OPTIONS>--systemproperties ${basedir}/src/test/resources/system-properties.properties</EXTRA_MICRO_OPTIONS>
                             </environmentVariables>
                         </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>payara-micro-remote</id>
+            <properties>
+                <payara.micro/>
+            </properties>
+            <build>
+                <plugins>
+                    <!-- Configure Payara Micro Runtime -->
+                    <plugin>
+                        <groupId>fish.payara.maven.plugins</groupId>
+                        <artifactId>payara-micro-maven-plugin</artifactId>
+                        <version>1.0.6</version>
+                        <executions>
+                            <!-- Restart Payara micro with additional property -->
+                            <execution>
+                                <id>stop-test-instance</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>restart-test-instance-properties</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                                <configuration>
+                                    <daemon>true</daemon>
+                                    <deployWar>false</deployWar>
+                                    <commandLineOptions>
+                                        <option>
+                                            <key>--deploy</key>
+                                            <value>${project.build.directory}/dependency/payara-micro-deployer.war</value>
+                                        </option>
+                                        <option>
+                                            <key>--nocluster</key>
+                                        </option>
+                                        <option>
+                                            <key>--logToFile</key>
+                                            <value>${project.build.directory}/payara-micro.log</value>
+                                        </option>
+                                        <option>
+                                            <key>--systemproperties</key>
+                                            <value>${basedir}/src/test/resources/system-properties.properties</value>
+                                        </option>
+                                    </commandLineOptions>
+                                </configuration>
+                            </execution>
+                        </executions>
                     </plugin>
                 </plugins>
             </build>

--- a/MicroProfile-Fault-Tolerance/pom.xml
+++ b/MicroProfile-Fault-Tolerance/pom.xml
@@ -168,5 +168,60 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>payara-micro-remote</id>
+            <build>
+                <plugins>
+                    <!-- Configure Payara Micro Runtime -->
+                    <plugin>
+                        <groupId>fish.payara.maven.plugins</groupId>
+                        <artifactId>payara-micro-maven-plugin</artifactId>
+                        <version>1.0.6</version>
+                        <executions>
+                            <!-- Restart Payara micro with additional property -->
+                            <execution>
+                                <id>stop-test-instance</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>restart-test-instance-properties</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                                <configuration>
+                                    <daemon>true</daemon>
+                                    <deployWar>false</deployWar>
+                                    <commandLineOptions>
+                                        <option>
+                                            <key>--deploy</key>
+                                            <value>${project.build.directory}/dependency/payara-micro-deployer.war</value>
+                                        </option>
+                                        <option>
+                                            <key>--nocluster</key>
+                                        </option>
+                                        <option>
+                                            <key>--logToFile</key>
+                                            <value>${project.build.directory}/payara-micro.log</value>
+                                        </option>
+                                        <option>
+                                            <key>--prebootcommandfile</key>
+                                            <value>${basedir}/micro-pre-boot-commands.txt</value>
+                                        </option>
+                                    </commandLineOptions>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <!-- Exclude some tests failing with Payara Micro -->
+                <mptck.suite>${basedir}/src/test/resources/tck-suite3.0-stable.xml</mptck.suite>
+            </properties> 
+        </profile>
     </profiles>
 </project>

--- a/MicroProfile-Fault-Tolerance/pom.xml
+++ b/MicroProfile-Fault-Tolerance/pom.xml
@@ -176,7 +176,7 @@
                     <plugin>
                         <groupId>fish.payara.maven.plugins</groupId>
                         <artifactId>payara-micro-maven-plugin</artifactId>
-                        <version>1.0.6</version>
+                        <version>${payara.micro.maven.plugin.version}</version>
                         <executions>
                             <!-- Restart Payara micro with additional property -->
                             <execution>
@@ -213,6 +213,13 @@
                                         </option>
                                     </commandLineOptions>
                                 </configuration>
+                            </execution>
+                            <execution>
+                                <id>stop-test-instance-properties</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
                             </execution>
                         </executions>
                     </plugin>

--- a/MicroProfile-JWT-Auth/tck-runner/pom.xml
+++ b/MicroProfile-JWT-Auth/tck-runner/pom.xml
@@ -128,5 +128,24 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>payara-micro-remote</id>
+            <build>
+                <plugins>
+                    <!-- Configure Payara Micro Runtime -->
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <systemPropertyVariables>
+                                <arquillian.launch>payara-micro-managed</arquillian.launch>
+                                <mp.jwt.tck.jwks.baseURL>http://localhost:8080/</mp.jwt.tck.jwks.baseURL>
+                                <mp.jwt.tck.pem.baseURL>http://localhost:8080/</mp.jwt.tck.pem.baseURL>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/MicroProfile-OpenTracing/pom.xml
+++ b/MicroProfile-OpenTracing/pom.xml
@@ -131,7 +131,7 @@
                         <id>prepare-payara-server</id>
                         <phase>pre-integration-test</phase>
                         <configuration>
-                            <target unless="payara.micro.managed">
+                            <target unless="payara.micro">
                                 <exec executable="${payara.executable}">
                                     <arg value="set-requesttracing-configuration" />
                                     <arg value="--enabled=true" />
@@ -213,7 +213,7 @@
         <profile>
             <id>payara-micro-managed</id>
             <properties>
-                <payara.micro.managed/>
+                <payara.micro/>
             </properties>
             <build>
                 <plugins>
@@ -224,6 +224,103 @@
                             <environmentVariables>
                                 <EXTRA_MICRO_OPTIONS>--postbootcommandfile ${basedir}/micro-post-boot-commands.txt --systemproperties tck.properties --addlibs ${basedir}/opentracing-mock-0.33.0-serviceloader.jar</EXTRA_MICRO_OPTIONS>
                             </environmentVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>payara-micro-remote</id>
+            <properties>
+                <payara.micro/>
+            </properties>
+            <build>
+                <plugins>
+                    <!-- Configure Payara Micro Runtime -->
+                    <plugin>
+                        <groupId>fish.payara.maven.plugins</groupId>
+                        <artifactId>payara-micro-maven-plugin</artifactId>
+                        <version>1.0.6</version>
+                        <executions>
+                            <!-- Restart Payara micro with additional library -->
+                            <execution>
+                                <id>stop-test-instance</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>restart-test-instance-mock</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                                <configuration>
+                                    <daemon>true</daemon>
+                                    <deployWar>false</deployWar>
+                                    <commandLineOptions>
+                                        <option>
+                                            <key>--deploy</key>
+                                            <value>${project.build.directory}/dependency/payara-micro-deployer.war</value>
+                                        </option>
+                                        <option>
+                                            <key>--nocluster</key>
+                                        </option>
+                                        <option>
+                                            <key>--logToFile</key>
+                                            <value>${project.build.directory}/payara-micro.log</value>
+                                        </option>
+                                        <option>
+                                            <key>--postbootcommandfile</key>
+                                            <value>${basedir}/micro-post-boot-commands.txt</value>
+                                        </option>
+                                        <option>
+                                            <key>--systemproperties</key>
+                                            <value>${basedir}/tck.properties</value>
+                                        </option>
+                                        <option>
+                                            <key>--addLibs</key>
+                                            <value>${basedir}/opentracing-mock-0.33.0-serviceloader.jar</value>
+                                        </option>
+                                    </commandLineOptions>
+                                </configuration>
+                            </execution>
+                            <!-- Restart Payara micro without additional library for next test suite -->
+                            <execution>
+                                <id>stop-test-instance-mock</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>restart-test-instance</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                                <configuration>
+                                    <daemon>true</daemon>
+                                    <deployWar>false</deployWar>
+                                    <commandLineOptions>
+                                        <option>
+                                            <key>--deploy</key>
+                                            <value>${project.build.directory}/dependency/payara-micro-deployer.war</value>
+                                        </option>
+                                        <option>
+                                            <key>--nocluster</key>
+                                        </option>
+                                        <option>
+                                            <key>--logToFile</key>
+                                            <value>${project.build.directory}/payara-micro.log</value>
+                                        </option>
+                                    </commandLineOptions>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <payaraVersion>${payara.version}</payaraVersion>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/MicroProfile-OpenTracing/pom.xml
+++ b/MicroProfile-OpenTracing/pom.xml
@@ -240,7 +240,7 @@
                     <plugin>
                         <groupId>fish.payara.maven.plugins</groupId>
                         <artifactId>payara-micro-maven-plugin</artifactId>
-                        <version>1.0.6</version>
+                        <version>${payara.micro.maven.plugin.version}</version>
                         <executions>
                             <!-- Restart Payara micro with additional library -->
                             <execution>
@@ -286,37 +286,12 @@
                                     </commandLineOptions>
                                 </configuration>
                             </execution>
-                            <!-- Restart Payara micro without additional library for next test suite -->
                             <execution>
                                 <id>stop-test-instance-mock</id>
                                 <phase>post-integration-test</phase>
                                 <goals>
                                     <goal>stop</goal>
                                 </goals>
-                            </execution>
-                            <execution>
-                                <id>restart-test-instance</id>
-                                <phase>post-integration-test</phase>
-                                <goals>
-                                    <goal>start</goal>
-                                </goals>
-                                <configuration>
-                                    <daemon>true</daemon>
-                                    <deployWar>false</deployWar>
-                                    <commandLineOptions>
-                                        <option>
-                                            <key>--deploy</key>
-                                            <value>${project.build.directory}/dependency/payara-micro-deployer.war</value>
-                                        </option>
-                                        <option>
-                                            <key>--nocluster</key>
-                                        </option>
-                                        <option>
-                                            <key>--logToFile</key>
-                                            <value>${project.build.directory}/payara-micro.log</value>
-                                        </option>
-                                    </commandLineOptions>
-                                </configuration>
                             </execution>
                         </executions>
                         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -68,10 +68,10 @@
         <jaxb.version>4.0.0-RC2</jaxb.version>
 
         <!-- Payara Dependencies -->
-        <payara.version>6.2021.1.Alpha2-SNAPSHOT</payara.version>
+        <payara.version>6.2023.2-SNAPSHOT</payara.version>
         <payara.home>${mptck.basedir}/target/payara6</payara.home>
         <payara.microJar>${mptck.basedir}/target/payara-micro-${payara.version}.jar</payara.microJar>
-        <micro.randomPort>true</micro.randomPort>
+        <micro.randomPort>false</micro.randomPort>
         <payara_domain>domain1</payara_domain>
     </properties>
 
@@ -258,9 +258,84 @@
                     <artifactId>payara-micro-remote</artifactId>
                     <version>${payara.arquillian.container.version}</version>
                     <scope>test</scope>
-                    <optional>true</optional>
+                </dependency>
+
+                <dependency>
+                    <groupId>fish.payara.arquillian</groupId>
+                    <artifactId>payara-micro-deployer</artifactId>
+                    <version>${payara.arquillian.container.version}</version>
+                    <scope>test</scope>
+                    <type>war</type>
                 </dependency>
             </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>deployer-for-tests</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>copy</goal>
+                                </goals>
+                                <configuration>
+                                    <artifactItems>
+                                        <artifactItem>
+                                            <groupId>fish.payara.arquillian</groupId>
+                                            <artifactId>payara-micro-deployer</artifactId>
+                                            <type>war</type>
+                                        </artifactItem>
+                                    </artifactItems>
+                                    <stripVersion>true</stripVersion>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>fish.payara.maven.plugins</groupId>
+                        <artifactId>payara-micro-maven-plugin</artifactId>
+                        <version>1.0.6</version>
+                        <executions>
+                            <execution>
+                                <id>start-test-instance</id>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>start</goal>
+                                </goals>
+                                <configuration>
+                                    <daemon>true</daemon>
+                                    <deployWar>false</deployWar>
+                                    <commandLineOptions>
+                                        <option>
+                                            <key>--deploy</key>
+                                            <value>${project.build.directory}/dependency/payara-micro-deployer.war</value>
+                                        </option>
+                                        <option>
+                                            <key>--nocluster</key>
+                                        </option>
+                                        <option>
+                                            <key>--logToFile</key>
+                                            <value>${project.build.directory}/payara-micro.log</value>
+                                        </option>
+                                    </commandLineOptions>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>stop-test-instance</id>
+                                <phase>post-integration-test</phase>
+                                <goals>
+                                    <goal>stop</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <payaraVersion>${payara.version}</payaraVersion>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>payara-server-embedded</id>

--- a/pom.xml
+++ b/pom.xml
@@ -297,7 +297,7 @@
                     <plugin>
                         <groupId>fish.payara.maven.plugins</groupId>
                         <artifactId>payara-micro-maven-plugin</artifactId>
-                        <version>1.0.6</version>
+                        <version>${payara.micro.maven.plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>start-test-instance</id>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <payara.microJar>${mptck.basedir}/target/payara-micro-${payara.version}.jar</payara.microJar>
         <micro.randomPort>false</micro.randomPort>
         <payara_domain>domain1</payara_domain>
+        <payara.micro.maven.plugin.version>1.0.6</payara.micro.maven.plugin.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Updating the Microprofile TCK runner to use the payara-micro-remote profile 
Caveats:
- Microprofile Config has 2 tests failing --> FISH-7050
- Microprofile JWT-Auth has 2 failing tests --> FISH-7051. 
- Microprofile Fault Tolerance - it runs a subset of the tests, excluding 40 additional failing tests --> FISH-7060
Example of results in Jenkins with these changes: https://jenkins.payara.fish/job/MPTCK-Dev/48/