### PR TITLE
Revert Jersey

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
 
         <!-- Embedded Dependencies -->
         <tyrus.version>2.0.0</tyrus.version>
-        <jersey.version>3.1.0.payara-p1</jersey.version>
+        <jersey.version>3.0.3.payara-p1</jersey.version>
         <cdi.version>4.0.1</cdi.version>
         <jaxb.version>4.0.0-RC2</jaxb.version>
 


### PR DESCRIPTION
This reverts commit b06f0ab579def0aef715be580cd396236da2470c.

Upgrading Jersey breaks Metrics. Upgrading Jersey and Arquillian to 3.0.alpha7 has Metrics pass, but then breaks Fault Tolerance.

Just reverting Jersey for now.