### PR TITLE
Revert upgrade of microprofile metrics to 5

### DIFF
--- a/MicroProfile-Metrics/pom.xml
+++ b/MicroProfile-Metrics/pom.xml
@@ -55,8 +55,8 @@
 
     <properties>
         <!-- Metrics Dependencies -->
-        <microprofile.metrics.version>5.0.0</microprofile.metrics.version>
-        <microprofile.metrics.tck.version>5.0.0</microprofile.metrics.tck.version>
+        <microprofile.metrics.version>4.0.1</microprofile.metrics.version>
+        <microprofile.metrics.tck.version>4.0.1</microprofile.metrics.tck.version>
         <micro.randomPort>false</micro.randomPort>
 
         <!-- Other Test Dependencies -->


### PR DESCRIPTION
This reverts commit 99c77af4b2a93666c3867bedfb1cba324376670d.

This was unlucky case of premature code integration, as server do not yet support metrics 5.