### PR TITLE
FISH-6976: upgrading microprofile metrics to 5

### DIFF
--- a/MicroProfile-Metrics/pom.xml
+++ b/MicroProfile-Metrics/pom.xml
@@ -55,8 +55,8 @@
 
     <properties>
         <!-- Metrics Dependencies -->
-        <microprofile.metrics.version>4.0.1</microprofile.metrics.version>
-        <microprofile.metrics.tck.version>4.0.1</microprofile.metrics.tck.version>
+        <microprofile.metrics.version>5.0.0</microprofile.metrics.version>
+        <microprofile.metrics.tck.version>5.0.0</microprofile.metrics.tck.version>
         <micro.randomPort>false</micro.randomPort>
 
         <!-- Other Test Dependencies -->

--- a/MicroProfile-Metrics/pom.xml
+++ b/MicroProfile-Metrics/pom.xml
@@ -96,6 +96,12 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.metrics</groupId>
+            <artifactId>microprofile-metrics-optional-tck</artifactId>
+            <version>${microprofile.metrics.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>5.2.0</version>
@@ -127,6 +133,7 @@
                     <dependenciesToScan>
                         <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-api-tck</dependency>
                         <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-rest-tck</dependency>
+                        <dependency>org.eclipse.microprofile.metrics:microprofile-metrics-optional-tck</dependency>
                     </dependenciesToScan>
                     <includes>
                         <include>**/*Test.java</include>

--- a/MicroProfile-Metrics/pom.xml
+++ b/MicroProfile-Metrics/pom.xml
@@ -138,6 +138,9 @@
                     <includes>
                         <include>**/*Test.java</include>
                     </includes>
+                    <excludes>
+                        <exclude>**/MpMetricOptionalTest.java</exclude>
+                    </excludes>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
This is to upgrade the metrics tck to 5

after excluding the optional test for Rest.request we have the following results:
`
[INFO] Tests run: 147, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO]
[INFO] --- maven-failsafe-plugin:3.0.0-M5:verify (verify) @ metrics-tck ---
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
`