### PR TITLE
Upgrade MP OpenAPI to 3.1 (TCK to patched version)

### DIFF
--- a/MicroProfile-OpenAPI/pom.xml
+++ b/MicroProfile-OpenAPI/pom.xml
@@ -2,7 +2,7 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-   Copyright (c) [2020-2021] Payara Foundation and/or its affiliates. All rights reserved.
+   Copyright (c) [2020-2023] Payara Foundation and/or its affiliates. All rights reserved.
 
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development
@@ -57,7 +57,8 @@
         <microprofile.openapi.version>3.1</microprofile.openapi.version>
         <microprofile.openapi.tck.version>3.1.payara-p1</microprofile.openapi.tck.version>
         <mptck.suite>${basedir}/src/test/resources/tck-suite.xml</mptck.suite>
-
+        <payara.executable>${payara.home}/bin/asadmin</payara.executable>
+        
         <!-- OpenAPI test url -->
         <test.url>http://localhost:8080/openapi/</test.url>
     </properties>
@@ -102,6 +103,69 @@
 
     <build>
         <plugins>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>start-payara-server</id>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <target if="payara.server.managed">
+                                <exec executable="${payara.executable}">
+                                    <arg value="start-domain" />
+                                </exec>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>prepare-payara-server</id>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <target unless="payara.micro.managed">
+                                <exec executable="${payara.executable}">
+                                    <arg value="set" />
+                                    <arg value="configs.config.server-config.network-config.network-listeners.network-listener.http-listener-2.enabled=true" />
+                                </exec>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>stop-payara-server</id>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <target if="payara.server.managed">
+                                <exec executable="${payara.executable}">
+                                    <arg value="stop-domain" />
+                                </exec>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>restart-remote-payara-server</id>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <target if="payara.server.remote">
+                                <exec executable="${payara.executable}">
+                                    <arg value="restart-domain" />
+                                    <arg value="${payara_domain}" />
+                                </exec>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>

--- a/MicroProfile-OpenAPI/pom.xml
+++ b/MicroProfile-OpenAPI/pom.xml
@@ -54,8 +54,8 @@
 
     <properties>
         <!-- Latest version of Microprofile Dependencies set via profiles -->
-        <microprofile.openapi.version>3.0</microprofile.openapi.version>
-        <microprofile.openapi.tck.version>3.0</microprofile.openapi.tck.version>
+        <microprofile.openapi.version>3.1</microprofile.openapi.version>
+        <microprofile.openapi.tck.version>3.1.payara-p1</microprofile.openapi.tck.version>
         <mptck.suite>${basedir}/src/test/resources/tck-suite.xml</mptck.suite>
 
         <!-- OpenAPI test url -->

--- a/MicroProfile-OpenAPI/pom.xml
+++ b/MicroProfile-OpenAPI/pom.xml
@@ -89,6 +89,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
             <version>1.81</version>
@@ -127,7 +131,7 @@
                             <target unless="payara.micro.managed">
                                 <exec executable="${payara.executable}">
                                     <arg value="set" />
-                                    <arg value="configs.config.server-config.network-config.network-listeners.network-listener.http-listener-2.enabled=true" />
+                                    <arg value="configs.config.server-config.network-config.network-listeners.network-listener.http-listener-2.enabled=false" />
                                 </exec>
                             </target>
                         </configuration>


### PR DESCRIPTION
Testing OpenAPI 3.1
TCK needs fix, e.g. upgrading to this patched version

Still needs:

- [x] configure payara: disable https (to have only 1 server)
- [ ] pass TCK