### PR TITLE
FISH-7118 Fix OpenAPI Micro Profile

### DIFF
--- a/MicroProfile-OpenAPI/pom.xml
+++ b/MicroProfile-OpenAPI/pom.xml
@@ -189,5 +189,11 @@
                 <test.url>http://localhost:8181/openapi/</test.url>
             </properties>
         </profile>
+        <profile>
+            <id>payara-micro-managed</id>
+            <properties>
+                <payara.micro.managed/>
+            </properties>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Was missing a property so that the asadmin commands would be skipped.