### PR TITLE
FISH-7118 Fix for Windows

### DIFF
--- a/MicroProfile-OpenAPI/pom.xml
+++ b/MicroProfile-OpenAPI/pom.xml
@@ -189,5 +189,16 @@
                 <test.url>http://localhost:8181/openapi/</test.url>
             </properties>
         </profile>
+        <profile>
+            <id>windows-profile</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <properties>
+                <payara.executable>${payara.home}/bin/asadmin.bat</payara.executable>
+            </properties>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Title.
Needs to set asadmin to use the .bat file.