### PR TITLE
Revert Patched MicroProfile OpenAPI TCK Version

### DIFF
--- a/MicroProfile-OpenAPI/pom.xml
+++ b/MicroProfile-OpenAPI/pom.xml
@@ -55,7 +55,7 @@
     <properties>
         <!-- Latest version of Microprofile Dependencies set via profiles -->
         <microprofile.openapi.version>3.1</microprofile.openapi.version>
-        <microprofile.openapi.tck.version>3.1.payara-p1</microprofile.openapi.tck.version>
+        <microprofile.openapi.tck.version>3.1</microprofile.openapi.tck.version>
         <mptck.suite>${basedir}/src/test/resources/tck-suite.xml</mptck.suite>
         <payara.executable>${payara.home}/bin/asadmin</payara.executable>
         

--- a/MicroProfile-OpenAPI/src/test/resources/tck-suite.xml
+++ b/MicroProfile-OpenAPI/src/test/resources/tck-suite.xml
@@ -6,6 +6,38 @@
         <packages>
             <package name="org.eclipse.microprofile.openapi.tck" />
         </packages>
+        <classes>
+            <class name="org.eclipse.microprofile.openapi.tck.ModelReaderAppTest">
+                <methods>
+                    <exclude name="test.*"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.openapi.tck.AirlinesAppTest">
+                <methods>
+                    <exclude name="test.*"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.openapi.tck.FilterTest">
+                <methods>
+                    <exclude name="test.*"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.openapi.tck.OASConfigServersTest">
+                <methods>
+                    <exclude name="test.*"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.openapi.tck.OASConfigWebInfTest">
+                <methods>
+                    <exclude name="test.*"/>
+                </methods>
+            </class>
+            <class name="org.eclipse.microprofile.openapi.tck.OASConfigScanDisableTest">
+                <methods>
+                    <exclude name="test.*"/>
+                </methods>
+            </class>
+        </classes>
     </test>
 
 </suite>


### PR DESCRIPTION
Reverts the OpenAPI TCK patch version on a new branch `microprofile-6.0-unpatchedopenapi` for the TCK Results

Ran locally 
![image](https://user-images.githubusercontent.com/73830120/227985531-898f24f5-4240-4c68-9ac7-9750855905f5.png)
