### PR TITLE
FISH-7339: Explicitly set OpenTracing span naming convention for OpenTracing TCK

### DIFF
--- a/MicroProfile-OpenTracing/src/test/java/fish/payara/microprofile/opentracingtck/mocktracing/TracingConfiguration.java
+++ b/MicroProfile-OpenTracing/src/test/java/fish/payara/microprofile/opentracingtck/mocktracing/TracingConfiguration.java
@@ -60,7 +60,8 @@ public class TracingConfiguration implements ConfigSourceProvider {
 
     private final static Map<String,String> props = Map.of("otel.sdk.disabled", "false",
             "otel.traces.exporter","opentracing-mock",
-            "otel.bsp.schedule.delay","10");
+            "otel.bsp.schedule.delay","10",
+            "payara.telemetry.span-convention", "opentracing-class-method");
 
     private enum MapSource implements ConfigSource {
         INSTANCE;


### PR DESCRIPTION
There was a hack in the server code to sense OpenTracing TCK and switch the convention whereas we are configuring the TCK test app anyway.