### PR TITLE
FISH-7339: Explicitly configure Telemetry Trace 1.0 naming convention in TCK

### DIFF
--- a/MicroProfile-OpenTelemetry-Tracing/pom.xml
+++ b/MicroProfile-OpenTelemetry-Tracing/pom.xml
@@ -65,6 +65,10 @@
             <artifactId>jakarta.jakartaee-web-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/MicroProfile-OpenTelemetry-Tracing/src/test/java/fish/payara/microprofile/telemetry/tracing/tck/ArquillianExtension.java
+++ b/MicroProfile-OpenTelemetry-Tracing/src/test/java/fish/payara/microprofile/telemetry/tracing/tck/ArquillianExtension.java
@@ -1,0 +1,107 @@
+/*
+ *
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright (c) 2023 Payara Foundation and/or its affiliates. All rights reserved.
+ *
+ *  The contents of this file are subject to the terms of either the GNU
+ *  General Public License Version 2 only ("GPL") or the Common Development
+ *  and Distribution License("CDDL") (collectively, the "License").  You
+ *  may not use this file except in compliance with the License.  You can
+ *  obtain a copy of the License at
+ *  https://github.com/payara/Payara/blob/master/LICENSE.txt
+ *  See the License for the specific
+ *  language governing permissions and limitations under the License.
+ *
+ *  When distributing the software, include this License Header Notice in each
+ *  file and include the License file at glassfish/legal/LICENSE.txt.
+ *
+ *  GPL Classpath Exception:
+ *  The Payara Foundation designates this particular file as subject to the "Classpath"
+ *  exception as provided by the Payara Foundation in the GPL Version 2 section of the License
+ *  file that accompanied this code.
+ *
+ *  Modifications:
+ *  If applicable, add the following below the License Header, with the fields
+ *  enclosed by brackets [] replaced by your own identifying information:
+ *  "Portions Copyright [year] [name of copyright owner]"
+ *
+ *  Contributor(s):
+ *  If you wish your version of this file to be governed by only the CDDL or
+ *  only the GPL Version 2, indicate your decision by adding "[Contributor]
+ *  elects to include this software in this distribution under the [CDDL or GPL
+ *  Version 2] license."  If you don't indicate a single choice of license, a
+ *  recipient has the option to distribute your version of this file under
+ *  either the CDDL, the GPL Version 2 or to extend the choice of license to
+ *  its licensees as provided above.  However, if you add GPL Version 2 code
+ *  and therefore, elected the GPL Version 2 license, then the option applies
+ *  only if the new code is made subject to such option by the copyright
+ *  holder.
+ *
+ */
+package fish.payara.microprofile.telemetry.tracing.tck;
+
+import io.opentelemetry.sdk.autoconfigure.spi.traces.ConfigurableSpanExporterProvider;
+import jakarta.enterprise.inject.spi.Extension;
+import org.eclipse.microprofile.config.spi.ConfigSource;
+import org.eclipse.microprofile.config.spi.ConfigSourceProvider;
+import org.glassfish.jersey.internal.spi.AutoDiscoverable;
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * @author ariekiswanto
+ */
+public class ArquillianExtension implements LoadableExtension {
+    @Override
+    public void register(ExtensionBuilder extensionBuilder) {
+        extensionBuilder.service(ApplicationArchiveProcessor.class, ApplicationArchiveProcessorImpl.class);
+    }
+
+    /**
+     * @author ariekiswanto
+     */
+    public static class ApplicationArchiveProcessorImpl implements ApplicationArchiveProcessor {
+        @Override
+        public void process(Archive<?> archive, TestClass testClass) {
+            WebArchive webArchive = WebArchive.class.cast(archive);
+            // json serialization of traces
+            webArchive
+                    // OpenTelemetry setup
+                    .addAsServiceProvider(ConfigSource.class, SpanNaming.class)
+                    .addClass(SpanNaming.class);
+        }
+    }
+
+    /**
+     * OpenTelemetry 1.13-compatible span naming needs to be followed for TCK 1.0, but not for TCK 1.1, this can be removed with MP 7.0 support
+     */
+    public static class SpanNaming implements ConfigSource {
+        private final static Map<String,String> properties = Map.of("payara.telemetry.span-convention", "OpenTelemetry-1.13");
+        @Override
+        public Set<String> getPropertyNames() {
+            return properties.keySet();
+        }
+
+        @Override
+        public String getValue(String s) {
+            return properties.get(s);
+        }
+
+        @Override
+        public String getName() {
+            return "MP TCK Span Naming configuration";
+        }
+
+        @Override
+        public Map<String, String> getProperties() {
+            return properties;
+        }
+    }
+}

--- a/MicroProfile-OpenTelemetry-Tracing/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/MicroProfile-OpenTelemetry-Tracing/src/test/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+fish.payara.microprofile.telemetry.tracing.tck.ArquillianExtension


### PR DESCRIPTION
Turns out that Tracing TCK also didn't have explicit span convention defined.

This will not be necessary for TCK 1.1, but I removed the special cases in the server already.

This adds synthetic config source to the test apps that define the span naming strategy required by TCK -- `OpenTelemetry-1.13`