### PR TITLE
FISH-7767: Update to Telemetry 1.1

### DIFF
--- a/MicroProfile-OpenTelemetry-Tracing/pom.xml
+++ b/MicroProfile-OpenTelemetry-Tracing/pom.xml
@@ -69,6 +69,10 @@
             <artifactId>microprofile-config-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
@@ -86,7 +90,7 @@
     </dependencies>
 
     <properties>
-        <microprofile.telemetry.version>1.0</microprofile.telemetry.version>
+        <microprofile.telemetry.version>1.1</microprofile.telemetry.version>
         <mptck.suite>${basedir}/src/test/resources/tck-suite.xml</mptck.suite>
     </properties>
 

--- a/MicroProfile-OpenTelemetry-Tracing/pom.xml
+++ b/MicroProfile-OpenTelemetry-Tracing/pom.xml
@@ -90,7 +90,7 @@
     </dependencies>
 
     <properties>
-        <microprofile.telemetry.version>1.1</microprofile.telemetry.version>
+        <microprofile.telemetry.version>1.1-RC3</microprofile.telemetry.version>
         <mptck.suite>${basedir}/src/test/resources/tck-suite.xml</mptck.suite>
     </properties>
 

--- a/MicroProfile-OpenTelemetry-Tracing/src/test/resources/tck-suite.xml
+++ b/MicroProfile-OpenTelemetry-Tracing/src/test/resources/tck-suite.xml
@@ -40,13 +40,21 @@
   ~  holder.
   ~
   -->
-<suite name="microprofile-opentracing-TCK" verbose="2" configfailurepolicy="continue" >
 
-    <test name="microprofile-telemetry 1.0 TCK">
+<suite name="MicroProfile Telemetry Tracing TCK" verbose="2" configfailurepolicy="continue" >
+    <test name="telemetry-tracing-tests" verbose="10">
+        <groups>
+            <run>
+                <!-- Exclude B3 and Jaeger propagation tests-->
+                <exclude name="optional-tests"/>
+            </run>
+        </groups>
         <packages>
-            <package name="org.eclipse.microprofile.telemetry.tracing.tck.*">
-            </package>
+            <package name="org.eclipse.microprofile.telemetry.tracing.tck.*" />
         </packages>
+        <!-- Uncomment to run a single test -->
+<!--        <classes>-->
+<!--            <class name="org.eclipse.microprofile.telemetry.tracing.tck.async.JaxRsServerAsyncTest"></class>-->
+<!--        </classes>-->
     </test>
-
 </suite>

--- a/MicroProfile-OpenTracing/src/test/java/fish/payara/microprofile/opentracingtck/mocktracing/MockTracerExporter.java
+++ b/MicroProfile-OpenTracing/src/test/java/fish/payara/microprofile/opentracingtck/mocktracing/MockTracerExporter.java
@@ -80,7 +80,7 @@ public class MockTracerExporter implements SpanExporter {
     private static void waitForNextExport() {
 
         long delay = TimeUnit.MILLISECONDS.toNanos(20);
-        for (int missed = 0; missed < 2; ) {
+        for (int missed = 0; missed < 4; ) {
             synchronized (mockTracer) {
                 try {
                     long nanos = System.nanoTime();


### PR DESCRIPTION
Wait until final or RC3 gets released.

Changes in opentracing needed to pass the tests on my machine, the exact timing of when OTEL exports the traces is hard to estimate and tests failed with no traces found.