### PR TITLE
FISH-7433: upgrading metrics to 5.1.0-RC1

### DIFF
--- a/MicroProfile-Metrics/pom.xml
+++ b/MicroProfile-Metrics/pom.xml
@@ -2,7 +2,7 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-   Copyright (c) [2017-2022] Payara Foundation and/or its affiliates. All rights reserved.
+   Copyright (c) [2017-2023] Payara Foundation and/or its affiliates. All rights reserved.
 
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development

--- a/MicroProfile-Metrics/pom.xml
+++ b/MicroProfile-Metrics/pom.xml
@@ -55,8 +55,8 @@
 
     <properties>
         <!-- Metrics Dependencies -->
-        <microprofile.metrics.version>5.0.0</microprofile.metrics.version>
-        <microprofile.metrics.tck.version>5.0.0</microprofile.metrics.tck.version>
+        <microprofile.metrics.version>5.1.0-RC1</microprofile.metrics.version>
+        <microprofile.metrics.tck.version>5.1.0-RC1</microprofile.metrics.tck.version>
         <micro.randomPort>false</micro.randomPort>
 
         <!-- Other Test Dependencies -->

--- a/MicroProfile-Metrics/pom.xml
+++ b/MicroProfile-Metrics/pom.xml
@@ -55,8 +55,8 @@
 
     <properties>
         <!-- Metrics Dependencies -->
-        <microprofile.metrics.version>5.1.0-RC1</microprofile.metrics.version>
-        <microprofile.metrics.tck.version>5.1.0-RC1</microprofile.metrics.tck.version>
+        <microprofile.metrics.version>5.1.0-RC1.payara-p1</microprofile.metrics.version>
+        <microprofile.metrics.tck.version>5.1.0-RC1.payara-p1</microprofile.metrics.tck.version>
         <micro.randomPort>false</micro.randomPort>
 
         <!-- Other Test Dependencies -->


### PR DESCRIPTION
This is to upgrade version of TCK runner using our patched version from metrics 5.1.0-RC1