### PR TITLE
FISH-7988 - tests with jdk21

### DIFF
--- a/MicroProfile-Config/pom.xml
+++ b/MicroProfile-Config/pom.xml
@@ -195,16 +195,14 @@
             </build>
         </profile>
         <profile>
-            <id>Jdk21</id>
+            <id>Jdk17+</id>
             <activation>
-                <jdk>21</jdk>
+                <jdk>[17,)</jdk>
             </activation>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>2.22.0</version>
+                        <artifactId>maven-failsafe-plugin</artifactId>
                         <configuration>
                             <argLine>--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED --add-exports=java.base/sun.net.www=ALL-UNNAMED --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.desktop/java.beans=ALL-UNNAMED --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED</argLine>
                         </configuration>

--- a/MicroProfile-Config/pom.xml
+++ b/MicroProfile-Config/pom.xml
@@ -194,5 +194,23 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>Jdk21</id>
+            <activation>
+                <jdk>21</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.22.0</version>
+                        <configuration>
+                            <argLine>--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED --add-exports=java.base/sun.net.www=ALL-UNNAMED --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.desktop/java.beans=ALL-UNNAMED --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/MicroProfile-Health/tck-runner/pom.xml
+++ b/MicroProfile-Health/tck-runner/pom.xml
@@ -90,6 +90,7 @@
         </dependency>
     </dependencies>
     
+    <!-- 1 TCK fails in MP Health 4.0.1 with jdk17+, so we exclude it. See https://github.com/eclipse/microprofile-health/issues/324 -->
     <profiles>
         <profile>
             <id>Jdk17+</id>

--- a/MicroProfile-Health/tck-runner/pom.xml
+++ b/MicroProfile-Health/tck-runner/pom.xml
@@ -89,4 +89,16 @@
             </exclusions>
         </dependency>
     </dependencies>
+    
+    <profiles>
+        <profile>
+            <id>Jdk17+</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <properties>
+                <mptck.suite>${basedir}/src/test/resources/tck-suite-jdk17.xml</mptck.suite>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/MicroProfile-Health/tck-runner/src/test/resources/tck-suite-jdk17.xml
+++ b/MicroProfile-Health/tck-runner/src/test/resources/tck-suite-jdk17.xml
@@ -1,0 +1,18 @@
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="microprofile-fault-tolerance-TCK" verbose="2" configfailurepolicy="continue" >
+
+    <test name="microprofile-fault-tolerance 4.0.1 TCK">
+        <packages>
+            <package name="org.eclipse.microprofile.health.tck.*" />
+        </packages>
+        <classes>
+            <class name="org.eclipse.microprofile.health.tck.HealthCheckResponseValidationTest">
+                <methods>
+                    <exclude name="testValidateConcreteHealthCheckResponse"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
+
+</suite>

--- a/MicroProfile-Metrics/pom.xml
+++ b/MicroProfile-Metrics/pom.xml
@@ -162,4 +162,23 @@
             </plugin>
         </plugins>
     </build>
+    
+    <profiles>
+        <profile>
+            <id>Jdk17+</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <argLine>--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED --add-exports=java.base/sun.net.www=ALL-UNNAMED --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.desktop/java.beans=ALL-UNNAMED --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/MicroProfile-Rest-Client/apache-httpclient-connector/pom.xml
+++ b/MicroProfile-Rest-Client/apache-httpclient-connector/pom.xml
@@ -122,15 +122,15 @@
 
     <pluginRepositories>
         <pluginRepository>
+            <id>payara-nexus-artifacts</id>
+            <name>Payara Nexus Artifacts</name>
+            <url>https://nexus.dev.payara.fish/repository/payara-artifacts</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-            <id>payara-patched-externals</id>
-            <name>Payara Patched Externals</name>
-            <url>https://raw.github.com/payara/Payara_PatchedProjects/master</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/MicroProfile-Rest-Client/apache-httpclient-connector/pom.xml
+++ b/MicroProfile-Rest-Client/apache-httpclient-connector/pom.xml
@@ -227,7 +227,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>4.1.0</version>
+                <version>5.1.1</version>
                 <executions>
                     <execution>
                         <id>default-manifest</id>

--- a/pom.xml
+++ b/pom.xml
@@ -645,14 +645,14 @@
             <url>https://nexus.dev.payara.fish/repository/payara-artifacts/</url>
         </repository>
         <repository>
-            <id>payara.patched.projects</id>
-            <name>Payara_PatchedProjects Repository</name>
-            <url>https://raw.github.com/payara/Payara_PatchedProjects/master/</url>
+            <id>payara-nexus-artifacts</id>
+            <name>Payara Nexus Artifacts</name>
+            <url>https://nexus.dev.payara.fish/repository/payara-artifacts</url>
             <releases>
                 <enabled>true</enabled>
             </releases>
             <snapshots>
-                <enabled>true</enabled>
+                <enabled>false</enabled>
             </snapshots>
         </repository>
     </repositories>


### PR DESCRIPTION
Fixes to run the MP TCKs with JDK21, using Payara 6.

Run with Payara Enterprise 6: https://engineeringjenkins.payara.fish/job/BuildAndRunMPTCKs/14/

Run with Payara Community 6: https://engineeringjenkins.payara.fish/job/BuildAndRunMPTCKs/15/

Note, in Jenkins, I had to use RC to run the MP TCKs with the jdk21, as Payara cannot be built with that jdk at the moment.