### PR TITLE
FISH-8451 Add Jackson dependency for classes missing as of 2.17.0

### DIFF
--- a/MicroProfile-Health/tck-runner/pom.xml
+++ b/MicroProfile-Health/tck-runner/pom.xml
@@ -2,7 +2,7 @@
 <!--
    DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
 
-   Copyright (c) [2017-2021] Payara Foundation and/or its affiliates. All rights reserved.
+   Copyright (c) 2017-2024 Payara Foundation and/or its affiliates. All rights reserved.
 
    The contents of this file are subject to the terms of either the GNU
    General Public License Version 2 only ("GPL") or the Common Development
@@ -72,6 +72,12 @@
         <dependency>
             <groupId>fish.payara.arquillian</groupId>
             <artifactId>payara-client-ee9</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/MicroProfile-Health/tck-runner/pom.xml
+++ b/MicroProfile-Health/tck-runner/pom.xml
@@ -75,6 +75,7 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- This is required as of jackson 2.17.0 -->
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>


### PR DESCRIPTION
For https://github.com/payara/Payara/pull/6600

The version is defined in the Payara-BOM