### PR TITLE
FISH-11086: include bean validation tests

### DIFF
--- a/MicroProfile-OpenAPI/src/test/resources/tck-suite.xml
+++ b/MicroProfile-OpenAPI/src/test/resources/tck-suite.xml
@@ -4,7 +4,7 @@
 
     <test name="microprofile-openapi 3.0 TCK">
         <packages>
-            <package name="org.eclipse.microprofile.openapi.tck" />
+            <package name="org.eclipse.microprofile.openapi.tck.*" />
         </packages>
     </test>
 


### PR DESCRIPTION
This PR adds all of the tests under openapi.tck.*

Run against the latest community 6.2025.4:

[ERROR] Tests run: 317, Failures: 38, Errors: 0, Skipped: 0
