### PR TITLE
FISH-11374: add MicroProfile 6.1 support for Payara7

### DIFF
--- a/MicroProfile-Config/pom.xml
+++ b/MicroProfile-Config/pom.xml
@@ -59,7 +59,7 @@
         <microprofile.config.tck.version>3.1</microprofile.config.tck.version>
         <mptck.suite>${basedir}/src/test/resources/tck-suite.xml</mptck.suite>
         <micro.randomPort>false</micro.randomPort>
-        
+
     	<!-- Other Test Dependencies -->
     	<cdi.version>4.0.1</cdi.version>
         <payara.executable>${payara.home}/bin/asadmin</payara.executable>
@@ -80,7 +80,7 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.arquillian</groupId>
-            <artifactId>payara-client-ee9</artifactId>
+            <artifactId>payara-client-ee11</artifactId>
         </dependency>
 
         <dependency>

--- a/MicroProfile-Fault-Tolerance/pom.xml
+++ b/MicroProfile-Fault-Tolerance/pom.xml
@@ -87,7 +87,7 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.arquillian</groupId>
-            <artifactId>payara-client-ee9</artifactId>
+            <artifactId>payara-client-ee11</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>

--- a/MicroProfile-Health/tck-runner/pom.xml
+++ b/MicroProfile-Health/tck-runner/pom.xml
@@ -71,7 +71,7 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.arquillian</groupId>
-            <artifactId>payara-client-ee9</artifactId>
+            <artifactId>payara-client-ee11</artifactId>
             <scope>test</scope>
         </dependency>
 
@@ -96,7 +96,7 @@
             </exclusions>
         </dependency>
     </dependencies>
-    
+
     <!-- 1 TCK fails in MP Health 4.0.1 with jdk17+, so we exclude it. See https://github.com/eclipse/microprofile-health/issues/324 -->
     <profiles>
         <profile>

--- a/MicroProfile-Metrics/pom.xml
+++ b/MicroProfile-Metrics/pom.xml
@@ -116,7 +116,7 @@
 
         <dependency>
             <groupId>fish.payara.arquillian</groupId>
-            <artifactId>payara-client-ee9</artifactId>
+            <artifactId>payara-client-ee11</artifactId>
         </dependency>
         <dependency>
             <groupId>fish.payara.arquillian</groupId>
@@ -162,7 +162,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <profiles>
         <profile>
             <id>Jdk17+</id>

--- a/MicroProfile-OpenAPI/pom.xml
+++ b/MicroProfile-OpenAPI/pom.xml
@@ -58,7 +58,7 @@
         <microprofile.openapi.tck.version>3.1.1</microprofile.openapi.tck.version>
         <mptck.suite>${basedir}/src/test/resources/tck-suite.xml</mptck.suite>
         <payara.executable>${payara.home}/bin/asadmin</payara.executable>
-        
+
         <!-- OpenAPI test url -->
         <test.url>http://localhost:8080/openapi/</test.url>
     </properties>
@@ -100,7 +100,7 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.arquillian</groupId>
-            <artifactId>payara-client-ee9</artifactId>
+            <artifactId>payara-client-ee11</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/MicroProfile-Rest-Client/apache-httpclient-connector/pom.xml
+++ b/MicroProfile-Rest-Client/apache-httpclient-connector/pom.xml
@@ -59,18 +59,39 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <httpclient5.version>5.2.1</httpclient5.version>
     </properties>
 
     <dependencies>
+        <!-- MicroProfile Rest Client -->
         <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>
             <artifactId>microprofile-rest-client-api</artifactId>
             <version>${microprofile.rest.client.api.version}</version>
         </dependency>
+
+        <!-- Jersey with Apache HTTP Client -->
         <dependency>
             <groupId>org.glassfish.jersey.connectors</groupId>
             <artifactId>jersey-apache5-connector</artifactId>
             <version>${jersey.version}</version>
+        </dependency>
+
+        <!-- Apache HTTP Client 5 (Jakarta EE 9+) -->
+        <dependency>
+            <groupId>org.apache.httpcomponents.client5</groupId>
+            <artifactId>httpclient5</artifactId>
+            <version>${httpclient5.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5</artifactId>
+            <version>${httpclient5.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents.core5</groupId>
+            <artifactId>httpcore5-h2</artifactId>
+            <version>${httpclient5.version}</version>
         </dependency>
     </dependencies>
 
@@ -309,5 +330,4 @@
             </plugin>
         </plugins>
     </build>
-    
 </project>

--- a/MicroProfile-Rest-Client/apache-httpclient-connector/pom.xml
+++ b/MicroProfile-Rest-Client/apache-httpclient-connector/pom.xml
@@ -212,7 +212,7 @@
             <plugin>
                 <groupId>org.glassfish.hk2</groupId>
                 <artifactId>hk2-inhabitant-generator</artifactId>
-                <version>2.6.1.payara-p1</version>
+                <version>4.0.0-M2.payara-p2</version>
                 <executions>
                     <execution>
                         <goals>

--- a/MicroProfile-Rest-Client/apache-httpclient-connector/pom.xml
+++ b/MicroProfile-Rest-Client/apache-httpclient-connector/pom.xml
@@ -69,7 +69,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish.jersey.connectors</groupId>
-            <artifactId>jersey-apache-connector</artifactId>
+            <artifactId>jersey-apache5-connector</artifactId>
             <version>${jersey.version}</version>
         </dependency>
     </dependencies>

--- a/MicroProfile-Rest-Client/apache-httpclient-connector/pom.xml
+++ b/MicroProfile-Rest-Client/apache-httpclient-connector/pom.xml
@@ -76,23 +76,6 @@
             <artifactId>jersey-apache5-connector</artifactId>
             <version>${jersey.version}</version>
         </dependency>
-
-        <!-- Apache HTTP Client 5 (Jakarta EE 9+) -->
-        <dependency>
-            <groupId>org.apache.httpcomponents.client5</groupId>
-            <artifactId>httpclient5</artifactId>
-            <version>${httpclient5.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents.core5</groupId>
-            <artifactId>httpcore5</artifactId>
-            <version>${httpclient5.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents.core5</groupId>
-            <artifactId>httpcore5-h2</artifactId>
-            <version>${httpclient5.version}</version>
-        </dependency>
     </dependencies>
 
     <repositories>

--- a/MicroProfile-Rest-Client/apache-httpclient-connector/pom.xml
+++ b/MicroProfile-Rest-Client/apache-httpclient-connector/pom.xml
@@ -55,8 +55,8 @@
     <name>MicroProfile Rest Client Apache HTTP Client Connector</name>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>

--- a/MicroProfile-Rest-Client/apache-httpclient-connector/src/main/java/fish/payara/microprofile/restclient/apache/httpclient/RestClientApacheHttpClientListener.java
+++ b/MicroProfile-Rest-Client/apache-httpclient-connector/src/main/java/fish/payara/microprofile/restclient/apache/httpclient/RestClientApacheHttpClientListener.java
@@ -42,13 +42,13 @@ package fish.payara.microprofile.restclient.apache.httpclient;
 
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 import org.eclipse.microprofile.rest.client.spi.RestClientListener;
-import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
+import org.glassfish.jersey.apache5.connector.Apache5ConnectorProvider;
 
 public class RestClientApacheHttpClientListener implements RestClientListener {
 
     @Override
     public void onNewClient(Class<?> aClass, RestClientBuilder restClientBuilder) {
-        restClientBuilder.register(new ApacheConnectorProvider());
+        restClientBuilder.register(new Apache5ConnectorProvider());
     }
 
 }

--- a/MicroProfile-Rest-Client/pom.xml
+++ b/MicroProfile-Rest-Client/pom.xml
@@ -54,8 +54,8 @@
     <name>MicroProfile Rest Client TCK Runner - Parent</name>
 
     <properties>
-        <microprofile.rest.client.tck.version>4.0</microprofile.rest.client.tck.version>
-        <microprofile.rest.client.api.version>4.0</microprofile.rest.client.api.version>
+        <microprofile.rest.client.tck.version>3.0.1</microprofile.rest.client.tck.version>
+        <microprofile.rest.client.api.version>3.0.1</microprofile.rest.client.api.version>
     </properties>
 
     <modules>

--- a/MicroProfile-Rest-Client/pom.xml
+++ b/MicroProfile-Rest-Client/pom.xml
@@ -54,8 +54,8 @@
     <name>MicroProfile Rest Client TCK Runner - Parent</name>
 
     <properties>
-        <microprofile.rest.client.tck.version>3.0.1</microprofile.rest.client.tck.version>
-        <microprofile.rest.client.api.version>3.0.1</microprofile.rest.client.api.version>
+        <microprofile.rest.client.tck.version>4.0</microprofile.rest.client.tck.version>
+        <microprofile.rest.client.api.version>4.0</microprofile.rest.client.api.version>
     </properties>
 
     <modules>

--- a/MicroProfile-Rest-Client/smallrye-config-repackaged/pom.xml
+++ b/MicroProfile-Rest-Client/smallrye-config-repackaged/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd"> 
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.smallrye.config</groupId>

--- a/MicroProfile-Rest-Client/tck-runners/apache-http-client/pom.xml
+++ b/MicroProfile-Rest-Client/tck-runners/apache-http-client/pom.xml
@@ -112,7 +112,7 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.glassfish.jersey.connectors</groupId>
-                                    <artifactId>jersey-apache-connector</artifactId>
+                                    <artifactId>jersey-apache5-connector</artifactId>
                                     <version>${jersey.version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
@@ -156,7 +156,7 @@
                                     <arg value="${payara.home}/glassfish/modules/"/>
                                 </exec>
                                 <exec executable="cp">
-                                    <arg value="${project.build.directory}/dependency/jersey-apache-connector-${jersey.version}.jar"/>
+                                    <arg value="${project.build.directory}/dependency/jersey-apache5-connector-${jersey.version}.jar"/>
                                     <arg value="${payara.home}/glassfish/modules/"/>
                                 </exec>
                                 <exec executable="cp">
@@ -201,7 +201,7 @@
                                     <arg value="${payara.home}/glassfish/modules/commons-logging-${apache.commons.logging.version}.jar"/>
                                 </exec>
                                 <exec executable="rm">
-                                    <arg value="${payara.home}/glassfish/modules/jersey-apache-connector-${jersey.version}.jar"/>
+                                    <arg value="${payara.home}/glassfish/modules/jersey-apache5-connector-${jersey.version}.jar"/>
                                 </exec>
                                 <exec executable="rm">
                                     <arg value="${payara.home}/glassfish/modules/apache-httpclient-connector-${project.version}.jar"/>

--- a/MicroProfile-Rest-Client/tck-runners/apache-http-client/pom.xml
+++ b/MicroProfile-Rest-Client/tck-runners/apache-http-client/pom.xml
@@ -56,8 +56,8 @@
     </description>
 
     <properties>
-        <apache.httpclient.version>4.5.13</apache.httpclient.version>
-        <apache.httpcore.version>4.4.14</apache.httpcore.version>
+        <apache.httpclient.version>4.5.14</apache.httpclient.version>
+        <apache.httpcore.version>4.4.16</apache.httpcore.version>
         <apache.commons.logging.version>1.2</apache.commons.logging.version>
 
         <payara.executable>${payara.home}/bin/asadmin</payara.executable>

--- a/MicroProfile-Rest-Client/tck-runners/apache-http-client/src/test/resources/META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientListener
+++ b/MicroProfile-Rest-Client/tck-runners/apache-http-client/src/test/resources/META-INF/services/org.eclipse.microprofile.rest.client.spi.RestClientListener
@@ -1,0 +1,1 @@
+fish.payara.microprofile.restclient.apache.httpclient.RestClientApacheHttpClientListener

--- a/MicroProfile-Rest-Client/tck-runners/pom.xml
+++ b/MicroProfile-Rest-Client/tck-runners/pom.xml
@@ -108,7 +108,7 @@
         </dependency>
         <dependency>
             <groupId>fish.payara.arquillian</groupId>
-            <artifactId>payara-client-ee9</artifactId>
+            <artifactId>payara-client-ee11</artifactId>
             <scope>test</scope>
             <exclusions>
                 <!-- depending on version of ee8-client, the possibly
@@ -166,5 +166,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -54,22 +54,24 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <!-- Java Version Dependencies -->
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
 
         <!-- Arquillian Dependencies -->
-        <version.arquillian>1.7.0.Alpha14</version.arquillian>
-        <payara.arquillian.container.version>3.0.alpha8</payara.arquillian.container.version>
+        <version.arquillian>1.9.5.Final</version.arquillian>
+        <payara.arquillian.container.version>3.1</payara.arquillian.container.version>
 
         <!-- Embedded Dependencies -->
-        <tyrus.version>2.0.0</tyrus.version>
+        <tyrus.version>2.2.0</tyrus.version>
         <jersey.version>3.0.3.payara-p1</jersey.version>
         <cdi.version>4.0.1</cdi.version>
         <jaxb.version>4.0.0</jaxb.version>
+        <shrinkwrap.version>3.3.4</shrinkwrap.version>
+        <jakarta.json.version>2.1.3</jakarta.json.version>
 
         <!-- Payara Dependencies -->
         <payara.version>6.2023.1</payara.version>
-        <payara.home>${mptck.basedir}/target/payara6</payara.home>
+        <payara.home>${mptck.basedir}/target/payara7</payara.home>
         <payara.microJar>${mptck.basedir}/target/payara-micro-${payara.version}.jar</payara.microJar>
         <micro.randomPort>true</micro.randomPort>
         <payara_domain>domain1</payara_domain>
@@ -104,6 +106,7 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-api-maven</artifactId>
+            <version>${shrinkwrap.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
@@ -113,6 +116,7 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <version>${shrinkwrap.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -289,6 +293,7 @@
                 <dependency>
                     <groupId>org.glassfish</groupId>
                     <artifactId>jakarta.json</artifactId>
+                    <version>${jakarta.json.version}</version>
                     <scope>test</scope>
                 </dependency>
                 <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,9 @@
 
         <!-- Embedded Dependencies -->
         <tyrus.version>2.2.0</tyrus.version>
-        <jersey.version>3.0.3.payara-p1</jersey.version>
-        <cdi.version>4.0.1</cdi.version>
-        <jaxb.version>4.0.0</jaxb.version>
+        <jersey.version>4.0.0-M2.payara-p1</jersey.version>
+        <cdi.version>4.1.0</cdi.version>
+        <jaxb.version>4.0.2</jaxb.version>
         <shrinkwrap.version>3.3.4</shrinkwrap.version>
         <jakarta.json.version>2.1.3</jakarta.json.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
         <jakarta.json.version>2.1.3</jakarta.json.version>
 
         <!-- Payara Dependencies -->
-        <payara.version>7.2025.1.Alpha3-SNAPSHOT</payara.version>
+        <payara.version>7.2025.1.Alpha2</payara.version>
         <payara.home>${mptck.basedir}/target/payara7</payara.home>
         <payara.microJar>${mptck.basedir}/target/payara-micro-${payara.version}.jar</payara.microJar>
         <micro.randomPort>true</micro.randomPort>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 
         <!-- Arquillian Dependencies -->
         <version.arquillian>1.9.5.Final</version.arquillian>
-        <payara.arquillian.container.version>3.1</payara.arquillian.container.version>
+        <payara.arquillian.container.version>4.0.alpha2</payara.arquillian.container.version>
 
         <!-- Embedded Dependencies -->
         <tyrus.version>2.2.0</tyrus.version>
@@ -70,11 +70,16 @@
         <jakarta.json.version>2.1.3</jakarta.json.version>
 
         <!-- Payara Dependencies -->
-        <payara.version>6.2023.1</payara.version>
+        <payara.version>7.2025.1.Alpha3-SNAPSHOT</payara.version>
         <payara.home>${mptck.basedir}/target/payara7</payara.home>
         <payara.microJar>${mptck.basedir}/target/payara-micro-${payara.version}.jar</payara.microJar>
         <micro.randomPort>true</micro.randomPort>
         <payara_domain>domain1</payara_domain>
+
+        <jakarta-staging.repo.releases.enabled>false</jakarta-staging.repo.releases.enabled>
+        <jakarta-staging.repo.snapshots.enabled>false</jakarta-staging.repo.snapshots.enabled>
+        <payara-nexus-staging.repo.releases.enabled>false</payara-nexus-staging.repo.releases.enabled>
+        <payara-nexus-staging.repo.snapshots.enabled>false</payara-nexus-staging.repo.snapshots.enabled>
     </properties>
 
     <modules>
@@ -139,6 +144,22 @@
 
     <!-- Profile specific dependencies -->
     <profiles>
+        <profile>
+            <id>payara-nexus-staging</id>
+            <properties>
+                <payara-nexus-staging.repo.releases.enabled>true</payara-nexus-staging.repo.releases.enabled>
+                <payara-nexus-staging.repo.snapshots.enabled>true</payara-nexus-staging.repo.snapshots.enabled>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>jakarta-staging</id>
+            <properties>
+                <jakarta-staging.repo.releases.enabled>true</jakarta-staging.repo.releases.enabled>
+                <jakarta-staging.repo.snapshots.enabled>true</jakarta-staging.repo.snapshots.enabled>
+            </properties>
+        </profile>
+
         <profile>
             <id>payara5plus</id>
             <activation>
@@ -477,7 +498,7 @@
             </dependency>
             <dependency>
                 <groupId>fish.payara.arquillian</groupId>
-                <artifactId>payara-client-ee9</artifactId>
+                <artifactId>payara-client-ee11</artifactId>
                 <version>${payara.arquillian.container.version}</version>
                 <scope>test</scope>
                 <exclusions>
@@ -645,9 +666,31 @@
     </build>
 
     <repositories>
+        <!-- Try Maven central first, not last, which happens when omitted here -->
+        <repository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>ossrh-snapshots</id>
+            <name>Sonatype OSSRH Snapshot Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
         <repository>
             <id>payara-nexus-artifacts</id>
-            <name>Payara Nexus Artifacts</name>
             <url>https://nexus.dev.payara.fish/repository/payara-artifacts</url>
             <releases>
                 <enabled>true</enabled>
@@ -656,5 +699,101 @@
                 <enabled>false</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>payara-nexus-snapshots</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>payara-nexus-staging</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-staging</url>
+            <releases>
+                <enabled>${payara-nexus-staging.repo.releases.enabled}</enabled>
+            </releases>
+            <snapshots>
+                <enabled>${payara-nexus-staging.repo.snapshots.enabled}</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>jakarta-releases</id>
+            <url>https://jakarta.oss.sonatype.org/content/groups/staging/</url>
+            <releases>
+                <enabled>${jakarta-staging.repo.releases.enabled}</enabled>
+            </releases>
+            <snapshots>
+                <enabled>${jakarta-staging.repo.snapshots.enabled}</enabled>
+            </snapshots>
+        </repository>
     </repositories>
+
+    <pluginRepositories>
+        <!-- Try Maven central first, not last, which happens when omitted here -->
+        <pluginRepository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>ossrh-snapshots</id>
+            <name>Sonatype OSSRH Snapshot Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>payara-nexus-artifacts</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-artifacts</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>payara-nexus-snapshots</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>payara-nexus-staging</id>
+            <url>https://nexus.dev.payara.fish/repository/payara-staging</url>
+            <releases>
+                <enabled>${payara-nexus-staging.repo.releases.enabled}</enabled>
+            </releases>
+            <snapshots>
+                <enabled>${payara-nexus-staging.repo.snapshots.enabled}</enabled>
+            </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+            <id>jakarta-releases</id>
+            <url>https://jakarta.oss.sonatype.org/content/groups/staging/</url>
+            <releases>
+                <enabled>${jakarta-staging.repo.releases.enabled}</enabled>
+            </releases>
+            <snapshots>
+                <enabled>${jakarta-staging.repo.snapshots.enabled}</enabled>
+            </snapshots>
+        </pluginRepository>
+    </pluginRepositories>
 </project>


### PR DESCRIPTION
This PR adds MicroProfile 6.1 Support for Payara7.

7.2025.1Alpha2 runs:
- Full: https://jenkins.payara.fish/blue/organizations/jenkins/MP-TCKs/detail/MP-TCKs/130/pipeline
- Web: https://jenkins.payara.fish/blue/organizations/jenkins/MP-TCKs/detail/MP-TCKs/131/pipeline
