### PR TITLE
FISH-10759 Deployment Descriptors

### DIFF
--- a/MicroProfile-JWT-Auth/tck-arquillian-extension/src/main/java/fish/payara/microprofile/jwtauth/tck/ArquillianArchiveProcessor.java
+++ b/MicroProfile-JWT-Auth/tck-arquillian-extension/src/main/java/fish/payara/microprofile/jwtauth/tck/ArquillianArchiveProcessor.java
@@ -80,7 +80,7 @@ public class ArquillianArchiveProcessor implements ApplicationArchiveProcessor {
             webArchive.addAsResource("payara-mp-jwt.properties");
         }
         webArchive.addAsWebInfResource("web.xml")
-                .addAsWebInfResource("glassfish-web.xml");
+                .addAsWebInfResource("payara-web.xml");
 
         LOGGER.log(INFO, "Augmenting virtual web archive: {0}", archive);
         LOGGER.log(INFO, "Virtually augmented web archive: \n{0}", webArchive.toString(true));

--- a/MicroProfile-JWT-Auth/tck-arquillian-extension/src/main/resources/glassfish-web.xml
+++ b/MicroProfile-JWT-Auth/tck-arquillian-extension/src/main/resources/glassfish-web.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE glassfish-web-app PUBLIC "-//GlassFish.org//DTD GlassFish Application Server 3.1 Servlet 3.0//EN" "http://glassfish.org/dtds/glassfish-web-app_3_0-1.dtd">
-<glassfish-web-app error-url="">
-  <context-root>/</context-root>
-</glassfish-web-app>

--- a/MicroProfile-JWT-Auth/tck-arquillian-extension/src/main/resources/payara-web.xml
+++ b/MicroProfile-JWT-Auth/tck-arquillian-extension/src/main/resources/payara-web.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE payara-web-app PUBLIC "-//Payara.fish//DTD Payara Server 4 Servlet 3.0//EN" "https://docs.payara.fish/schemas/payara-web-app_4.dtd">
+<payara-web-app error-url="">
+  <context-root>/</context-root>
+</payara-web-app>


### PR DESCRIPTION
Replaces the outdated `glassfish-web.xml` with `payara-web.xml`.

Required for [FISH-10759](https://github.com/payara/Payara/pull/7925).

[FISH-10759]: https://payara.atlassian.net/browse/FISH-10759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ