### PR TITLE
FISH-12023 OpenAPI 4.1 TCK

### DIFF
--- a/MicroProfile-OpenAPI/pom.xml
+++ b/MicroProfile-OpenAPI/pom.xml
@@ -54,8 +54,8 @@
 
     <properties>
         <!-- Latest version of Microprofile Dependencies set via profiles -->
-        <microprofile.openapi.version>3.1.1</microprofile.openapi.version>
-        <microprofile.openapi.tck.version>3.1.1</microprofile.openapi.tck.version>
+        <microprofile.openapi.version>4.1</microprofile.openapi.version>
+        <microprofile.openapi.tck.version>4.1</microprofile.openapi.tck.version>
         <mptck.suite>${basedir}/src/test/resources/tck-suite.xml</mptck.suite>
         <payara.executable>${payara.home}/bin/asadmin</payara.executable>
 

--- a/MicroProfile-OpenAPI/src/test/resources/tck-suite.xml
+++ b/MicroProfile-OpenAPI/src/test/resources/tck-suite.xml
@@ -2,7 +2,7 @@
 
 <suite name="microprofile-openapi-TCK" verbose="2" configfailurepolicy="continue" >
 
-    <test name="microprofile-openapi 3.0 TCK">
+    <test name="microprofile-openapi 4.1 TCK">
         <packages>
             <package name="org.eclipse.microprofile.openapi.tck.*" />
         </packages>


### PR DESCRIPTION
Updates the OpenAPI TCK to use version 4.1.

The TCK was tested against the FISH-9740-MicroProfile-7.1 branch of Payara, most of the tests fail according to the changes in OpenAPI 4.1.