### PR TITLE
FISH-12818: adding configuration to enable telemetry-log-tck execution

### DIFF
--- a/MicroProfile-OpenTelemetry/pom.xml
+++ b/MicroProfile-OpenTelemetry/pom.xml
@@ -50,6 +50,8 @@
         <artifactId>tck-suite-parent</artifactId>
         <version>1.1-SNAPSHOT</version>
     </parent>
+    
+    <packaging>jar</packaging>
 
     <artifactId>MicroProfile-OpenTelemetry</artifactId>
 
@@ -57,6 +59,12 @@
         <dependency>
             <groupId>org.eclipse.microprofile.telemetry</groupId>
             <artifactId>microprofile-telemetry-tracing-tck</artifactId>
+            <version>${microprofile.telemetry.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.microprofile.telemetry</groupId>
+            <artifactId>microprofile-telemetry-logs-tck</artifactId>
             <version>${microprofile.telemetry.version}</version>
             <scope>test</scope>
         </dependency>
@@ -89,8 +97,157 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.5.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>create-directory</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${payara.home}${file.separator}glassfish${file.separator}domains${file.separator}domain1${file.separator}lib${file.separator}ext"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-jar-to-server</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${payara.home}${file.separator}glassfish${file.separator}domains${file.separator}domain1${file.separator}lib${file.separator}ext</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.build.directory}</directory>
+                                    <includes>
+                                        <include>${project.build.finalName}.jar</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.6.3</version>
+                <executions>
+                    <execution>
+                        <id>start-server</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>${payara.home}${file.separator}bin</workingDirectory>
+                            <executable>${payara.executable}</executable>
+                            <arguments>
+                                <argument>start-domain</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>setting-log-file-location</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>${payara.home}${file.separator}bin</workingDirectory>
+                            <executable>${payara.executable}</executable>
+                            <arguments>
+                                <argument>create-system-properties</argument>
+                                <argument>mptelemetry.tck.log.file.path=${payara.home}${file.separator}glassfish${file.separator}domains${file.separator}domain1${file.separator}logs${file.separator}server.log</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>setting-custom-log-formatter</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>${payara.home}${file.separator}bin</workingDirectory>
+                            <executable>${payara.executable}</executable>
+                            <arguments>
+                                <argument>set-log-file-format</argument>
+                                <argument>--target</argument>
+                                <argument>server</argument>
+                                <argument>fish.payara.microprofile.telemetry.tck.CustomLoggerFormatter</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>restart-server</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>${payara.home}${file.separator}bin</workingDirectory>
+                            <executable>${payara.executable}</executable>
+                            <arguments>
+                                <argument>restart-domain</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>stop-server</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <workingDirectory>${payara.home}${file.separator}bin</workingDirectory>
+                            <executable>${payara.executable}</executable>
+                            <arguments>
+                                <argument>stop-domain</argument>
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>windows-profile</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <properties>
+                <payara.executable>${payara.home}${file.separator}bin${file.separator}asadmin.bat</payara.executable>
+            </properties>
+        </profile>
+    </profiles>
+
     <properties>
         <microprofile.telemetry.version>2.1</microprofile.telemetry.version>
         <mptck.suite>${basedir}/src/test/resources/tck-suite.xml</mptck.suite>
+        <payara.executable>./asadmin</payara.executable>
     </properties>
 </project>

--- a/MicroProfile-OpenTelemetry/src/main/java/fish/payara/microprofile/telemetry/tck/CustomLoggerFormatter.java
+++ b/MicroProfile-OpenTelemetry/src/main/java/fish/payara/microprofile/telemetry/tck/CustomLoggerFormatter.java
@@ -1,0 +1,15 @@
+package fish.payara.microprofile.telemetry.tck;
+
+import java.util.logging.Formatter;
+import java.util.logging.LogRecord;
+
+public class CustomLoggerFormatter extends Formatter {
+    
+    @Override
+    public String format(LogRecord record) {
+        String message = record.getMessage();
+        message += " scopeInfo:full";
+        return String.format("[%s] [%s] %s %n",
+                record.getMillis(), record.getLevel(), message);
+    }
+}

--- a/MicroProfile-OpenTelemetry/src/test/resources/tck-suite.xml
+++ b/MicroProfile-OpenTelemetry/src/test/resources/tck-suite.xml
@@ -41,12 +41,11 @@
   ~
   -->
 
-<suite name="MicroProfile Telemetry Tracing TCK" verbose="2" configfailurepolicy="continue" >
-    <test name="telemetry-tracing-tests" verbose="10">
+<suite name="MicroProfile Telemetry Tracing TCK" verbose="10" configfailurepolicy="continue" >
+    <test name="telemetry-tracing-tck-tests" verbose="10">
         <groups>
             <run>
-                <!-- Exclude B3 and Jaeger propagation tests-->
-                <exclude name="optional-tests"/>
+                <exclude name="optional-tests"></exclude>
             </run>
         </groups>
         <packages>
@@ -57,4 +56,19 @@
 <!--            <class name="org.eclipse.microprofile.telemetry.tracing.tck.async.JaxRsServerAsyncTest"></class>-->
 <!--        </classes>-->
     </test>
+    <test name="telemetry-logs-tck-tests" verbose="10">
+        <groups>
+            <run>
+                <exclude name="optional-tests"></exclude>
+            </run>
+        </groups>
+        <packages>
+            <package name="org.eclipse.microprofile.telemetry.logs.tck.application.*"/>
+        </packages>
+        <!-- Uncomment to run a single test -->
+        <!--        <classes>-->
+        <!--            <class name="org.eclipse.microprofile.telemetry.tracing.tck.async.JaxRsServerAsyncTest"></class>-->
+        <!--        </classes>-->
+    </test>
+    
 </suite>


### PR DESCRIPTION
This is the configuration to execute the MicroProfile Telemetry logs tck's

The current results are:

<img width="1199" height="440" alt="image" src="https://github.com/user-attachments/assets/dae9b94e-7cdb-4663-898a-5a9fda765a19" />

this configuration only works for linux because the step to set the property mptelemetry.tck.log.file.path on windows fail because if you set the value with a path on windows this is always removing the C:\ part from the path, causing failure to execute the command, here the command I used on windows and the error reported from logs:

`
mvn verify -Dpayara.version=7.2026.2-SNAPSHOT -Dpayara.home=C:\java\projects\Payara\appserver\distributions\payara\target\stage\payara7
`

``
CommandModel ETag: zm04DRol00PdO1QWMYvVKA==
Writer to use com.sun.enterprise.admin.remote.writer.ParameterMapFormProprietaryWriter
Response code: 500
Result type is application/json;charset=UTF-8
URL connection is sun.net.www.protocol.http.HttpURLConnection
------ ACTION REPORT ------
ACTION REPORT - 0 [FAILURE]
 actionDescription: create-system-properties command
 failure: Invalid property syntax, missing property value: \java\projects\Payara\appserver\distributions\payara\target\stage\payara7\glassfish\domains\domain1\logs\server.log
    MESSAGE - 0.M0
     : Invalid property syntax, missing property value: \java\projects\Payara\appserver\distributions\payara\target\stage\payara7\glassfish\domains\domain1\logs\server.log
        MESSAGE - 0.M0.M0
         : Usage: create-system-properties
        [--target <target(default:server)>] [-?|--help[=<help(default:false)>]]
        (name=value)[:name=value]*


---- END ACTION REPORT ----
doHttpCommand succeeds
remote failure: Invalid property syntax, missing property value: \java\projects\Payara\appserver\distributions\payara\target\stage\payara7\glassfish\domains\domain1\logs\server.log
Invalid property syntax, missing property value: \java\projects\Payara\appserver\distributions\payara\target\stage\payara7\glassfish\domains\domain1\logs\server.log
Usage: create-system-properties
        [--target <target(default:server)>] [-?|--help[=<help(default:false)>]]
        (name=value)[:name=value]*
Command create-system-properties failed.
``

I tried to scape with double quotes and also with forward slashes, but any of those options worked for me. It seems something on the rest implementation to interpret the value added on the property for the command