### PR TITLE
FISH-13162 ModelConstructionTest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -494,7 +494,6 @@
             <dependency>
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
-                <!-- Version 7.5+ requires slf4j-api, which is not in payara-web or micro -->
                 <version>7.12.0</version>
                 <scope>test</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
                                 <goals>
                                     <goal>unpack</goal>
                                 </goals>
-                                <phase>process-test-resources</phase>
+                                <phase>pre-integration-test</phase>
                                 <configuration>
                                     <skip>${skipConfig}</skip>
                                     <artifactItems>
@@ -575,9 +575,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
             <plugin>
                 <groupId>org.commonjava.maven.plugins</groupId>
                 <artifactId>directory-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -495,7 +495,13 @@
                 <groupId>org.testng</groupId>
                 <artifactId>testng</artifactId>
                 <!-- Version 7.5+ requires slf4j-api, which is not in payara-web or micro -->
-                <version>7.4.0</version>
+                <version>7.12.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>2.0.16</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
                                 <goals>
                                     <goal>unpack</goal>
                                 </goals>
-                                <phase>pre-integration-test</phase>
+                                <phase>process-test-resources</phase>
                                 <configuration>
                                     <skip>${skipConfig}</skip>
                                     <artifactItems>


### PR DESCRIPTION
- Updates the TestNG version to 7.12.0 for the OpenAPI TCK.
  - Adds slf4j as a dependency (required by TestNG).
- Adjusts the phase of the unpack-server goal to fix the Jenkins issues.