### PR TITLE
FISH-12028: update of fault tolerance version to 4.1.2

### DIFF
--- a/MicroProfile-Fault-Tolerance/pom.xml
+++ b/MicroProfile-Fault-Tolerance/pom.xml
@@ -55,8 +55,8 @@
 
     <properties>
         <!-- Defaults for API and TCK dependencies - latest version -->
-        <microprofile.fault-tolerance.version>4.0.2</microprofile.fault-tolerance.version>
-        <microprofile.fault-tolerance.tck.version>4.0.2</microprofile.fault-tolerance.tck.version>
+        <microprofile.fault-tolerance.version>4.1.2</microprofile.fault-tolerance.version>
+        <microprofile.fault-tolerance.tck.version>4.1.2</microprofile.fault-tolerance.tck.version>
         <microprofile.metrics.version>5.0.0</microprofile.metrics.version>
         <mptck.suite>${basedir}/src/test/resources/tck-suite4.0.xml</mptck.suite>
     </properties>
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <version>4.0.3</version>
+            <version>4.2.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Updating Fault Tolerance version to review TCK results:

results from TCK:

<img width="1357" height="268" alt="image" src="https://github.com/user-attachments/assets/00a9be1e-866d-43da-a697-303ad39c6bd3" />

