### PR TITLE
FISH-12022 FISH-13639 FISH-13641 FISH-13644 FISH-13643 FISH-13644 FISH-13645 FISH-13646 FISH-13647 REST Client TCK

### DIFF
--- a/MicroProfile-Rest-Client/tck-runners/pom.xml
+++ b/MicroProfile-Rest-Client/tck-runners/pom.xml
@@ -136,6 +136,11 @@
             <artifactId>jersey-mp-rest-client</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-multipart</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- TCK needs standalone mp config implementation. Ours works only remotely -->
         <dependency>
             <groupId>io.smallrye.config</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -530,7 +530,7 @@
             <dependency>
                 <groupId>com.github.tomakehurst</groupId>
                 <artifactId>wiremock</artifactId>
-                <version>2.27.2</version>
+                <version>3.0.1</version>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
- Adds Jersey MultiPart to the TCK runner.
  - Resolves FISH-13642
- Updates Wiremock to version 3.0.1
  - Resolves all other TCK failures:
    - FISH-13639
    - FISH-13641
    - FISH-13643
    - FISH-13644
    - FISH-13645
    - FISH-13646
    - FISH-13647

[Jenkins Test](https://jenkins.payara.fish/view/TCKs/job/TCKs/job/MP-TCKs/8303/testReport/) with TCK passing.

(Relies on [Payara PR](https://github.com/payara/Payara/pull/8186))