### PR TITLE
FISH-13662: adding missed Jdk17+ profile to execute open telemetry tck tests

### DIFF
--- a/MicroProfile-OpenTelemetry/pom.xml
+++ b/MicroProfile-OpenTelemetry/pom.xml
@@ -91,4 +91,23 @@
         <module>MicroProfile-OpenTelemetry-JVM-Metrics-Runtime</module>
         <module>MicroProfile-OpenTelemetry-JVM-Metrics-Application</module>
     </modules>
+
+    <profiles>
+        <profile>
+            <id>Jdk17+</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <configuration>
+                            <argLine>--add-opens=java.base/jdk.internal.loader=ALL-UNNAMED --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED --add-exports=java.base/jdk.internal.ref=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/sun.nio.ch=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jrt=ALL-UNNAMED --add-exports=java.base/sun.net.www=ALL-UNNAMED --add-exports=java.base/sun.security.util=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.desktop/java.beans=ALL-UNNAMED --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED --add-opens=java.base/sun.net.www.protocol.jar=ALL-UNNAMED --add-opens=java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
Adding missed profile to execute the TCK using following commands:

```
mvn verify -f MicroProfile-OpenTelemetry/MicroProfile-OpenTelemetry-JVM-Metrics-Runtime/pom.xml -Dpayara.version=7.2026.4-SNAPSHOT -Dpayara.home=/home/alfv83/projects/Payara/appserver/distributions/payara/target/stage/payara7

mvn verify -f MicroProfile-OpenTelemetry/MicroProfile-OpenTelemetry-JVM-Metrics-Application/pom.xml -Dpayara.version=7.2026.4-SNAPSHOT -Dpayara.home=/home/alfv83/projects/Payara/appserver/distributions/payara/target/stage/payara7

mvn verify -f MicroProfile-OpenTelemetry/MicroProfile-OpenTelemetry-Tracing-Logging/pom.xml -Dpayara.version=7.2026.4-SNAPSHOT -Dpayara.home=/home/alfv83/projects/Payara/appserver/distributions/payara/target/stage/payara7
```